### PR TITLE
AlsoSlidingWindow End OpHit if in in_

### DIFF
--- a/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
@@ -84,7 +84,7 @@ namespace pmtana{
     //threshold += _ped_mean;
 
     Reset();
-    
+
     for(size_t i=0; i<wf.size(); ++i) {
 
       double value = 0.;
@@ -143,7 +143,7 @@ namespace pmtana{
 
         // If there's a pulse, end we where in in_post, end the previous pulse first
         if(in_post) {
-          // Find were 
+          // Find were
           _pulse.t_end = i - buffer_num_index - 1;
 
           // Register if width is acceptable
@@ -225,7 +225,7 @@ namespace pmtana{
 	in_tail = false;
 	in_post = false;
       }
-      
+
       if(fire || in_tail || in_post){
 
 	//_pulse.area += ((double)value - (double)mean_v[i]);

--- a/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
@@ -141,6 +141,22 @@ namespace pmtana{
 	  throw std::exception();
 	}
 
+        // If there's a pulse, end we where in in_post, end the previous pulse first
+        if(in_post) {
+          // Find were 
+          _pulse.t_end = i - buffer_num_index - 1;
+
+          // Register if width is acceptable
+          if( (_pulse.t_end - _pulse.t_start) >= _min_width )
+            _pulse_v.push_back(_pulse);
+
+          _pulse.reset_param();
+
+          if(_verbose)
+          std::cout << "\033[93mPulse End\033[00m: new pulse starts during in_post: "
+                          << "baseline: " << mean_v[i] << " ... " << " ... adc above: " << value << " T=" << i << std::endl;
+        }
+
 	_pulse.t_start   = i - buffer_num_index;
 	_pulse.ped_mean  = pulse_start_baseline;
 	_pulse.ped_sigma = sigma_v[i];


### PR DESCRIPTION
In AlgoSlidingWindow, ophits are found by looking where the waveform goes above baseline. When a peak (ophit) is found, the ophit is not eneded immediately, but after a few samples (in the code are called "in_post" samples). In case a new peak is found during an in_post sample, the previous peak is not ended. This causes a weird behaviour. This is now fixed by ending the previous pulse, and starting a new one.