### PR TITLE
Features to speed up photon library generation [2/2]

### DIFF
--- a/larana/OpticalDetector/SimPhotonCounter_module.cc
+++ b/larana/OpticalDetector/SimPhotonCounter_module.cc
@@ -373,52 +373,52 @@ namespace opdet {
       //switching off to add reading in of labelled collections: Andrzej, 02/26/19
 
         for (auto const& ph_handle: photon_handles) {
-         // Do some checking before we proceed
-         if (!ph_handle.isValid()) continue;
-         if (ph_handle.provenance()->moduleLabel() != mod) continue;   //not the most efficient way of doing this, but preserves the logic of the module. Andrzej
+          // Do some checking before we proceed
+          if (!ph_handle.isValid()) continue;
+          if (ph_handle.provenance()->moduleLabel() != mod) continue;   //not the most efficient way of doing this, but preserves the logic of the module. Andrzej
 
-        bool Reflected = (ph_handle.provenance()->productInstanceName() == "Reflected");
+          bool Reflected = (ph_handle.provenance()->productInstanceName() == "Reflected");
 
-        if((*ph_handle).size()>0)
-        {
-          if(fMakeLightAnalysisTree) {
-          //resetting the signalt to save in the analysis tree per event
-            const int maxNtracks = 1000;
-            for(size_t itrack=0; itrack!=maxNtracks; itrack++) {
-              for(size_t pmt_i=0; pmt_i!=geo->NOpChannels(); pmt_i++) {
-                fSignals_vuv[itrack][pmt_i].clear();
-                fSignals_vis[itrack][pmt_i].clear();
+          if((*ph_handle).size()>0)
+          {
+            if(fMakeLightAnalysisTree) {
+            //resetting the signalt to save in the analysis tree per event
+              const int maxNtracks = 1000;
+              for(size_t itrack=0; itrack!=maxNtracks; itrack++) {
+                for(size_t pmt_i=0; pmt_i!=geo->NOpChannels(); pmt_i++) {
+                  fSignals_vuv[itrack][pmt_i].clear();
+                  fSignals_vis[itrack][pmt_i].clear();
+                }
               }
             }
           }
-        }
 
 
-//      if(fVerbosity > 0) std::cout<<"Found OpDet hit collection of size "<< TheHitCollection.size()<<std::endl;
-        if(fVerbosity > 0) std::cout<<"Found OpDet hit collection of size "<< (*ph_handle).size()<<std::endl;
+  //      if(fVerbosity > 0) std::cout<<"Found OpDet hit collection of size "<< TheHitCollection.size()<<std::endl;
+          if(fVerbosity > 0) std::cout<<"Found OpDet hit collection of size "<< (*ph_handle).size()<<std::endl;
 
-        if((*ph_handle).size()>0)
-        {
-//           for(sim::SimPhotonsCollection::const_iterator itOpDet=TheHitCollection.begin(); itOpDet!=TheHitCollection.end(); itOpDet++)
-          for(auto const& itOpDet: (*ph_handle) )
+          if((*ph_handle).size()>0)
           {
-            //Reset Counters
-            fCountOpDetAll=0;
-            fCountOpDetDetected=0;
-            fCountOpDetReflDetected=0;
-            //Reset t0 for visible light
-            fT0_vis = 999.;
+  //           for(sim::SimPhotonsCollection::const_iterator itOpDet=TheHitCollection.begin(); itOpDet!=TheHitCollection.end(); itOpDet++)
+            for(auto const& itOpDet: (*ph_handle) )
+            {
+              //Reset Counters
+              fCountOpDetAll=0;
+              fCountOpDetDetected=0;
+              fCountOpDetReflDetected=0;
+              //Reset t0 for visible light
+              fT0_vis = 999.;
 
-            //Get data from HitCollection entry
-            fOpChannel=itOpDet.OpChannel();
-            const sim::SimPhotons& TheHit=itOpDet;
+              //Get data from HitCollection entry
+              fOpChannel=itOpDet.OpChannel();
+              const sim::SimPhotons& TheHit=itOpDet;
 
-            //std::cout<<"OpDet " << fOpChannel << " has size " << TheHit.size()<<std::endl;
+              //std::cout<<"OpDet " << fOpChannel << " has size " << TheHit.size()<<std::endl;
 
-            // Loop through OpDet phots.
-            //   Note we make the screen output decision outside the loop
-            //   in order to avoid evaluating large numbers of unnecessary
-            //   if conditions.
+              // Loop through OpDet phots.
+              //   Note we make the screen output decision outside the loop
+              //   in order to avoid evaluating large numbers of unnecessary
+              //   if conditions.
 
 
               for(const sim::OnePhoton& Phot: TheHit)
@@ -430,12 +430,13 @@ namespace opdet {
                 fTime= Phot.Time;
 
                 // special case for LibraryBuildJob: no working "Reflected" handle and all photons stored in single object - must sort using wavelength instead
-                if(fPVS->IsBuildJob() && !Reflected) { // all photons contained in object with Reflected = false flag
-                   // Increment per OpDet counters and fill per phot trees
+                if(fPVS->IsBuildJob() && !Reflected) {
+                  // all photons contained in object with Reflected = false flag
+                  // Increment per OpDet counters and fill per phot trees
                   fCountOpDetAll++;
                   if(fMakeAllPhotonsTree){
                     if (fWavelength < 200 || (fPVS->StoreReflected() && fWavelength > 200)) {
-                       fThePhotonTreeAll->Fill();
+                        fThePhotonTreeAll->Fill();
                     }
                   }
 
@@ -460,7 +461,7 @@ namespace opdet {
                       std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 0 "<<std::endl;
                   }
 
-                }
+                } // if build library and not reflected
 
                 else {
                   // store in appropriate trees using "Reflected" handle and fPVS->StoreReflected() flag
@@ -468,9 +469,9 @@ namespace opdet {
                   fCountOpDetAll++;
                   if(fMakeAllPhotonsTree){
                     if (!Reflected || (fPVS->StoreReflected() && Reflected)) {
-                       fThePhotonTreeAll->Fill();
+                        fThePhotonTreeAll->Fill();
                     }
-                   }
+                  }
 
                   if(odresponse->detected(fOpChannel, Phot))
                   {
@@ -493,91 +494,91 @@ namespace opdet {
                       std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 0 "<<std::endl;
                   }
                 }
+              } // for each photon in collection
+
+
+
+              // If this is a library building job, fill relevant entry
+              if(fPVS->IsBuildJob() && !Reflected) // for library build job, both componenents stored in first object with Reflected = false
+              {
+                int VoxID; double NProd;
+                fPVS->RetrieveLightProd(VoxID, NProd);
+                fPVS->SetLibraryEntry(VoxID, fOpChannel, double(fCountOpDetDetected)/NProd);
+
+                //store reflected light
+                if(fPVS->StoreReflected())
+                  fPVS->SetLibraryEntry(VoxID, fOpChannel, double(fCountOpDetReflDetected)/NProd,true);
+                //store reflected first arrival time
+                if(fPVS->StoreReflected() && fPVS->StoreReflT0())
+                  fPVS->SetLibraryReflT0Entry(VoxID, fOpChannel, fT0_vis);
               }
 
+              // Incremenent per event and fill Per OpDet trees
+              if(fMakeOpDetsTree) fTheOpDetTree->Fill();
+              fCountEventAll+=fCountOpDetAll;
+              fCountEventDetected+=fCountOpDetDetected;
 
-
-            // If this is a library building job, fill relevant entry
-            if(fPVS->IsBuildJob() && !Reflected) // for library build job, both componenents stored in first object with Reflected = false
-            {
-              int VoxID; double NProd;
-              fPVS->RetrieveLightProd(VoxID, NProd);
-              fPVS->SetLibraryEntry(VoxID, fOpChannel, double(fCountOpDetDetected)/NProd);
-
-              //store reflected light
-              if(fPVS->StoreReflected())
-                fPVS->SetLibraryEntry(VoxID, fOpChannel, double(fCountOpDetReflDetected)/NProd,true);
-              //store reflected first arrival time
-              if(fPVS->StoreReflected() && fPVS->StoreReflT0())
-                fPVS->SetLibraryReflT0Entry(VoxID, fOpChannel, fT0_vis);
+              // Give per OpDet output
+              if(fVerbosity >2) std::cout<<"OpDetResponseInterface PerOpDet : Event "<<fEventID<<" OpDet " << fOpChannel << " All " << fCountOpDetAll << " Det " <<fCountOpDetDetected<<std::endl;
             }
 
-            // Incremenent per event and fill Per OpDet trees
-            if(fMakeOpDetsTree) fTheOpDetTree->Fill();
-            fCountEventAll+=fCountOpDetAll;
-            fCountEventDetected+=fCountOpDetDetected;
+            // Fill per event tree
+            if(fMakeOpDetEventsTree) fTheEventTree->Fill();
 
-            // Give per OpDet output
-            if(fVerbosity >2) std::cout<<"OpDetResponseInterface PerOpDet : Event "<<fEventID<<" OpDet " << fOpChannel << " All " << fCountOpDetAll << " Det " <<fCountOpDetDetected<<std::endl;
+            // Give per event output
+            if(fVerbosity >1) std::cout<<"OpDetResponseInterface PerEvent : Event "<<fEventID<<" All " << fCountOpDetAll << " Det " <<fCountOpDetDetected<<std::endl;
+
           }
+          else
+          {
+            // if empty OpDet hit collection,
+            // add an empty record to the per event tree
+            if(fMakeOpDetEventsTree) fTheEventTree->Fill();
+          }
+          if(fMakeLightAnalysisTree) {
+            std::cout<<"Filling the analysis tree"<<std::endl;
+            //---------------Filling the analysis tree-----------:
+            fRun = evt.run();
+            std::vector<double> this_xyz;
 
-          // Fill per event tree
-          if(fMakeOpDetEventsTree) fTheEventTree->Fill();
+            //loop over the particles
+            for(simb::MCParticle const& pPart: *mcpartVec){
 
-          // Give per event output
-          if(fVerbosity >1) std::cout<<"OpDetResponseInterface PerEvent : Event "<<fEventID<<" All " << fCountOpDetAll << " Det " <<fCountOpDetDetected<<std::endl;
+              if(pPart.Process() == "primary")
+                fEnergy = pPart.E();
 
-        }
-        else
-        {
-          // if empty OpDet hit collection,
-          // add an empty record to the per event tree
-          if(fMakeOpDetEventsTree) fTheEventTree->Fill();
-        }
-        if(fMakeLightAnalysisTree) {
-          std::cout<<"Filling the analysis tree"<<std::endl;
-          //---------------Filling the analysis tree-----------:
-          fRun = evt.run();
-          std::vector<double> this_xyz;
-
-          //loop over the particles
-          for(simb::MCParticle const& pPart: *mcpartVec){
-
-            if(pPart.Process() == "primary")
-              fEnergy = pPart.E();
-
-            //resetting the vectors
-            fstepPositions.clear();
-            fstepTimes.clear();
-            fSignalsvuv.clear();
-            fSignalsvis.clear();
-            fdEdx = -1.;
-            //filling the tree fields
-            fTrackID = pPart.TrackId();
-            fpdg = pPart.PdgCode();
-            fmotherTrackID = pPart.Mother();
-            fdEdx = totalEnergy_track[fTrackID];
-            fSignalsvuv = fSignals_vuv[fTrackID];
-            fSignalsvis = fSignals_vis[fTrackID];
-            fProcess = pPart.Process();
-            //filling the center positions of each step
-            for(size_t i_s=1; i_s < pPart.NumberTrajectoryPoints(); i_s++){
-              this_xyz.clear();
-              this_xyz.resize(3);
-              this_xyz[0] = pPart.Position(i_s).X();
-              this_xyz[1] = pPart.Position(i_s).Y();
-              this_xyz[2] = pPart.Position(i_s).Z();
-              fstepPositions.push_back(this_xyz);
-              fstepTimes.push_back(pPart.Position(i_s).T());
+              //resetting the vectors
+              fstepPositions.clear();
+              fstepTimes.clear();
+              fSignalsvuv.clear();
+              fSignalsvis.clear();
+              fdEdx = -1.;
+              //filling the tree fields
+              fTrackID = pPart.TrackId();
+              fpdg = pPart.PdgCode();
+              fmotherTrackID = pPart.Mother();
+              fdEdx = totalEnergy_track[fTrackID];
+              fSignalsvuv = fSignals_vuv[fTrackID];
+              fSignalsvis = fSignals_vis[fTrackID];
+              fProcess = pPart.Process();
+              //filling the center positions of each step
+              for(size_t i_s=1; i_s < pPart.NumberTrajectoryPoints(); i_s++){
+                this_xyz.clear();
+                this_xyz.resize(3);
+                this_xyz[0] = pPart.Position(i_s).X();
+                this_xyz[1] = pPart.Position(i_s).Y();
+                this_xyz[2] = pPart.Position(i_s).Z();
+                fstepPositions.push_back(this_xyz);
+                fstepTimes.push_back(pPart.Position(i_s).T());
+              }
+              //filling the tree per track
+              fLightAnalysisTree->Fill();
             }
-            //filling the tree per track
-            fLightAnalysisTree->Fill();
-          }
+          } // if fMakeLightAnalysisTree
         }
       }
-     }
     }
-   if (fUseLitePhotons)
+    if (fUseLitePhotons)
     {
 
       //Get *ALL* SimPhotonsCollection from Event
@@ -599,97 +600,96 @@ namespace opdet {
 
           bool Reflected = (ph_handle.provenance()->productInstanceName() == "Reflected");
 
+          //Reset counters
+          fCountEventAll=0;
+          fCountEventDetected=0;
+
+          if(fVerbosity > 0) std::cout<<"Found OpDet hit collection of size "<< (*ph_handle).size()<<std::endl;
 
 
-      //Reset counters
-      fCountEventAll=0;
-      fCountEventDetected=0;
+          if((*ph_handle).size()>0)
+          {
 
-      if(fVerbosity > 0) std::cout<<"Found OpDet hit collection of size "<< (*ph_handle).size()<<std::endl;
+            for ( auto const& photon : (*ph_handle) )
+            {
+              //Get data from HitCollection entry
+              fOpChannel=photon.OpChannel;
+              std::map<int, int> PhotonsMap = photon.DetectedPhotons;
 
+              //Reset Counters
+              fCountOpDetAll=0;
+              fCountOpDetDetected=0;
+              fCountOpDetReflDetected=0;
 
-      if((*ph_handle).size()>0)
-      {
-
-        for ( auto const& photon : (*ph_handle) )
-        {
-          //Get data from HitCollection entry
-          fOpChannel=photon.OpChannel;
-          std::map<int, int> PhotonsMap = photon.DetectedPhotons;
-
-          //Reset Counters
-          fCountOpDetAll=0;
-          fCountOpDetDetected=0;
-          fCountOpDetReflDetected=0;
-
-         for(auto it = PhotonsMap.begin(); it!= PhotonsMap.end(); it++)
-           {
-             // Calculate wavelength in nm
-             if (Reflected) {
-                fWavelength = 450;
-             }
-             else {
-             fWavelength= 128;   // original
-             }
-
-             //Get arrival time from phot
-             fTime= it->first;
-             //std::cout<<"Arrival time: " << fTime<<std::endl;
-
-             for(int i = 0; i < it->second ; i++)
-             {
-                // Increment per OpDet counters and fill per phot trees
-                fCountOpDetAll++;
-                if(fMakeAllPhotonsTree) fThePhotonTreeAll->Fill();
-
-                if(odresponse->detectedLite(fOpChannel))
-                {
-                  if(fMakeDetectedPhotonsTree) fThePhotonTreeDetected->Fill();
-                  // direct light
-                  if (!Reflected){
-                    fCountOpDetDetected++;
-                  }
-                  else if (Reflected) {
-                    fCountOpDetReflDetected++;
-                  }
-                  if(fVerbosity > 3)
-                  std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 1 "<<std::endl;
+              for(auto it = PhotonsMap.begin(); it!= PhotonsMap.end(); it++)
+              {
+                // Calculate wavelength in nm
+                if (Reflected) {
+                  fWavelength = 450;
                 }
-                else
-                  if(fVerbosity > 3)
+                else {
+                  fWavelength= 128;   // original
+                }
+
+                //Get arrival time from phot
+                fTime= it->first;
+                //std::cout<<"Arrival time: " << fTime<<std::endl;
+
+                for(int i = 0; i < it->second ; i++)
+                {
+                  // Increment per OpDet counters and fill per phot trees
+                  fCountOpDetAll++;
+                  if(fMakeAllPhotonsTree) fThePhotonTreeAll->Fill();
+
+                  if(odresponse->detectedLite(fOpChannel))
                   {
-                  std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 0 "<<std::endl;
+                    if(fMakeDetectedPhotonsTree) fThePhotonTreeDetected->Fill();
+                    // direct light
+                    if (!Reflected){
+                      fCountOpDetDetected++;
+                    }
+                    else if (Reflected) {
+                      fCountOpDetReflDetected++;
+                    }
+                    if(fVerbosity > 3)
+                    std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 1 "<<std::endl;
                   }
+                  else
+                    if(fVerbosity > 3)
+                    {
+                    std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 0 "<<std::endl;
+                    }
+                }
               }
+
+
+
+              // Incremenent per event and fill Per OpDet trees
+              if(fMakeOpDetsTree) fTheOpDetTree->Fill();
+              fCountEventAll+=fCountOpDetAll;
+              fCountEventDetected+=fCountOpDetDetected;
+
+              // Give per OpDet output
+              if(fVerbosity >2) std::cout<<"OpDetResponseInterface PerOpDet : Event "<<fEventID<<" OpDet " << fOpChannel << " All " << fCountOpDetAll << " Det " <<fCountOpDetDetected<<std::endl;
             }
+            // Fill per event tree
+            if(fMakeOpDetEventsTree) fTheEventTree->Fill();
 
+            // Give per event output
+            if(fVerbosity >1) std::cout<<"OpDetResponseInterface PerEvent : Event "<<fEventID<<" All " << fCountOpDetAll << " Det " <<fCountOpDetDetected<<std::endl;
 
-
-          // Incremenent per event and fill Per OpDet trees
-          if(fMakeOpDetsTree) fTheOpDetTree->Fill();
-          fCountEventAll+=fCountOpDetAll;
-          fCountEventDetected+=fCountOpDetDetected;
-
-          // Give per OpDet output
-          if(fVerbosity >2) std::cout<<"OpDetResponseInterface PerOpDet : Event "<<fEventID<<" OpDet " << fOpChannel << " All " << fCountOpDetAll << " Det " <<fCountOpDetDetected<<std::endl;
+          }
+          else
+          {
+            // if empty OpDet hit collection,
+            // add an empty record to the per event tree
+            if(fMakeOpDetEventsTree) fTheEventTree->Fill();
+          }
         }
-        // Fill per event tree
-        if(fMakeOpDetEventsTree) fTheEventTree->Fill();
-
-        // Give per event output
-        if(fVerbosity >1) std::cout<<"OpDetResponseInterface PerEvent : Event "<<fEventID<<" All " << fCountOpDetAll << " Det " <<fCountOpDetDetected<<std::endl;
-
       }
-      else
-      {
-        // if empty OpDet hit collection,
-        // add an empty record to the per event tree
-        if(fMakeOpDetEventsTree) fTheEventTree->Fill();
-      }
-     }
     }
-  }
-  }
+  } // SimPhotonCounter::analyze()
+  
 }
 namespace opdet{
 

--- a/larana/OpticalDetector/SimPhotonCounter_module.cc
+++ b/larana/OpticalDetector/SimPhotonCounter_module.cc
@@ -63,6 +63,7 @@
 // C++ language includes
 #include <iostream>
 #include <cstring>
+#include <cassert>
 
 namespace opdet {
 
@@ -316,16 +317,16 @@ namespace opdet {
     // get the geometry to be able to figure out signal types and chan -> plane mappings
     art::ServiceHandle<geo::Geometry const> geo;
 
-    // get the MCtrue info of the particles
-    std::vector<simb::MCParticle> const* mcpartVec = fLightAnalysisTree
-      ? evt.getPointerByLabel<std::vector<simb::MCParticle>>("largeant")
-      : nullptr;
+    // GEANT4 info on the particles (only used if making light analysis tree)
+    std::vector<simb::MCParticle> const* mcpartVec = nullptr;
 
     //-------------------------initializing light tree vectors------------------------
     std::vector<double> totalEnergy_track;
     fstepPositions.clear();
     fstepTimes.clear();
     if (fMakeLightAnalysisTree) {
+      mcpartVec = evt.getPointerByLabel<std::vector<simb::MCParticle>>("largeant");
+      
       size_t maxNtracks = 1000U; // mcpartVec->size(); --- { to be fixed soon! ]
       fSignals_vuv.clear();
       fSignals_vuv.resize(maxNtracks);
@@ -553,6 +554,9 @@ namespace opdet {
             if(fMakeOpDetEventsTree) fTheEventTree->Fill();
           }
           if(fMakeLightAnalysisTree) {
+            assert(mcpartVec);
+            assert(fLightAnalysisTree);
+            
             std::cout<<"Filling the analysis tree"<<std::endl;
             //---------------Filling the analysis tree-----------:
             fRun = evt.run();

--- a/larana/OpticalDetector/SimPhotonCounter_module.cc
+++ b/larana/OpticalDetector/SimPhotonCounter_module.cc
@@ -187,7 +187,7 @@ namespace opdet {
     geo->CryostatBoundaries(CryoBounds);
     std::cout<<"Cryo Boundaries"<<std::endl;
     std::cout<<"Xmin: "<<CryoBounds[0]<<" Xmax: "<<CryoBounds[1]<<" Ymin: "<<CryoBounds[2]
-	     <<" Ymax: "<<CryoBounds[3]<<" Zmin: "<<CryoBounds[4]<<" Zmax: "<<CryoBounds[5]<<std::endl;
+             <<" Ymax: "<<CryoBounds[3]<<" Zmin: "<<CryoBounds[4]<<" Zmax: "<<CryoBounds[5]<<std::endl;
 
     try {
       pi_serv = &*(art::ServiceHandle<cheat::ParticleInventoryService const>());
@@ -366,7 +366,7 @@ namespace opdet {
       std::vector< art::Handle< std::vector< sim::SimPhotons > > > photon_handles;
       evt.getManyByType(photon_handles);
       if (photon_handles.size() == 0)
-	throw art::Exception(art::errors::ProductNotFound)<<"sim SimPhotons retrieved and you requested them.";
+        throw art::Exception(art::errors::ProductNotFound)<<"sim SimPhotons retrieved and you requested them.";
 
       for(auto const& mod : fInputModule){
       // sim::SimPhotonsCollection TheHitCollection = sim::SimListUtils::GetSimPhotonsCollection(evt,mod);
@@ -374,33 +374,33 @@ namespace opdet {
 
         for (auto const& ph_handle: photon_handles) {
          // Do some checking before we proceed
-	 if (!ph_handle.isValid()) continue;
-	 if (ph_handle.provenance()->moduleLabel() != mod) continue;   //not the most efficient way of doing this, but preserves the logic of the module. Andrzej
+         if (!ph_handle.isValid()) continue;
+         if (ph_handle.provenance()->moduleLabel() != mod) continue;   //not the most efficient way of doing this, but preserves the logic of the module. Andrzej
 
-	bool Reflected = (ph_handle.provenance()->productInstanceName() == "Reflected");
+        bool Reflected = (ph_handle.provenance()->productInstanceName() == "Reflected");
 
-	if((*ph_handle).size()>0)
-	{
-	  if(fMakeLightAnalysisTree) {
+        if((*ph_handle).size()>0)
+        {
+          if(fMakeLightAnalysisTree) {
           //resetting the signalt to save in the analysis tree per event
-	    const int maxNtracks = 1000;
-	    for(size_t itrack=0; itrack!=maxNtracks; itrack++) {
-	      for(size_t pmt_i=0; pmt_i!=geo->NOpChannels(); pmt_i++) {
-		fSignals_vuv[itrack][pmt_i].clear();
-		fSignals_vis[itrack][pmt_i].clear();
-	      }
-	    }
-	  }
-	}
+            const int maxNtracks = 1000;
+            for(size_t itrack=0; itrack!=maxNtracks; itrack++) {
+              for(size_t pmt_i=0; pmt_i!=geo->NOpChannels(); pmt_i++) {
+                fSignals_vuv[itrack][pmt_i].clear();
+                fSignals_vis[itrack][pmt_i].clear();
+              }
+            }
+          }
+        }
 
 
 //      if(fVerbosity > 0) std::cout<<"Found OpDet hit collection of size "<< TheHitCollection.size()<<std::endl;
-	if(fVerbosity > 0) std::cout<<"Found OpDet hit collection of size "<< (*ph_handle).size()<<std::endl;
+        if(fVerbosity > 0) std::cout<<"Found OpDet hit collection of size "<< (*ph_handle).size()<<std::endl;
 
         if((*ph_handle).size()>0)
         {
 //           for(sim::SimPhotonsCollection::const_iterator itOpDet=TheHitCollection.begin(); itOpDet!=TheHitCollection.end(); itOpDet++)
-	  for(auto const& itOpDet: (*ph_handle) )
+          for(auto const& itOpDet: (*ph_handle) )
           {
             //Reset Counters
             fCountOpDetAll=0;
@@ -429,15 +429,15 @@ namespace opdet {
                 //Get arrival time from phot
                 fTime= Phot.Time;
 
-		// special case for LibraryBuildJob: no working "Reflected" handle and all photons stored in single object - must sort using wavelength instead
-		if(fPVS->IsBuildJob() && !Reflected) { // all photons contained in object with Reflected = false flag
-	 	  // Increment per OpDet counters and fill per phot trees
+                // special case for LibraryBuildJob: no working "Reflected" handle and all photons stored in single object - must sort using wavelength instead
+                if(fPVS->IsBuildJob() && !Reflected) { // all photons contained in object with Reflected = false flag
+                   // Increment per OpDet counters and fill per phot trees
                   fCountOpDetAll++;
                   if(fMakeAllPhotonsTree){
-		    if (fWavelength < 200 || (fPVS->StoreReflected() && fWavelength > 200)) {
-         	      fThePhotonTreeAll->Fill();
+                    if (fWavelength < 200 || (fPVS->StoreReflected() && fWavelength > 200)) {
+                       fThePhotonTreeAll->Fill();
                     }
-		  }
+                  }
 
                   if(odresponse->detected(fOpChannel, Phot))
                   {
@@ -456,21 +456,21 @@ namespace opdet {
                       std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 1 "<<std::endl;
                   }
                   else {
-		    if(fVerbosity > 3)
+                    if(fVerbosity > 3)
                       std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 0 "<<std::endl;
-		  }
+                  }
 
-		}
+                }
 
-		else {
-		  // store in appropriate trees using "Reflected" handle and fPVS->StoreReflected() flag
+                else {
+                  // store in appropriate trees using "Reflected" handle and fPVS->StoreReflected() flag
                   // Increment per OpDet counters and fill per phot trees
                   fCountOpDetAll++;
                   if(fMakeAllPhotonsTree){
-		    if (!Reflected || (fPVS->StoreReflected() && Reflected)) {
-         	      fThePhotonTreeAll->Fill();
+                    if (!Reflected || (fPVS->StoreReflected() && Reflected)) {
+                       fThePhotonTreeAll->Fill();
                     }
-		   }
+                   }
 
                   if(odresponse->detected(fOpChannel, Phot))
                   {
@@ -489,10 +489,10 @@ namespace opdet {
                       std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 1 "<<std::endl;
                   }
                   else {
-		    if(fVerbosity > 3)
+                    if(fVerbosity > 3)
                       std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 0 "<<std::endl;
-		  }
-		}
+                  }
+                }
               }
 
 
@@ -502,7 +502,7 @@ namespace opdet {
             {
               int VoxID; double NProd;
               fPVS->RetrieveLightProd(VoxID, NProd);
-	      fPVS->SetLibraryEntry(VoxID, fOpChannel, double(fCountOpDetDetected)/NProd);
+              fPVS->SetLibraryEntry(VoxID, fOpChannel, double(fCountOpDetDetected)/NProd);
 
               //store reflected light
               if(fPVS->StoreReflected())
@@ -543,8 +543,8 @@ namespace opdet {
           //loop over the particles
           for(simb::MCParticle const& pPart: *mcpartVec){
 
-	    if(pPart.Process() == "primary")
-	      fEnergy = pPart.E();
+            if(pPart.Process() == "primary")
+              fEnergy = pPart.E();
 
             //resetting the vectors
             fstepPositions.clear();
@@ -553,27 +553,27 @@ namespace opdet {
             fSignalsvis.clear();
             fdEdx = -1.;
             //filling the tree fields
-	    fTrackID = pPart.TrackId();
-	    fpdg = pPart.PdgCode();
-	    fmotherTrackID = pPart.Mother();
-	    fdEdx = totalEnergy_track[fTrackID];
-	    fSignalsvuv = fSignals_vuv[fTrackID];
-	    fSignalsvis = fSignals_vis[fTrackID];
-	    fProcess = pPart.Process();
+            fTrackID = pPart.TrackId();
+            fpdg = pPart.PdgCode();
+            fmotherTrackID = pPart.Mother();
+            fdEdx = totalEnergy_track[fTrackID];
+            fSignalsvuv = fSignals_vuv[fTrackID];
+            fSignalsvis = fSignals_vis[fTrackID];
+            fProcess = pPart.Process();
             //filling the center positions of each step
             for(size_t i_s=1; i_s < pPart.NumberTrajectoryPoints(); i_s++){
-	      this_xyz.clear();
-	      this_xyz.resize(3);
-	      this_xyz[0] = pPart.Position(i_s).X();
-	      this_xyz[1] = pPart.Position(i_s).Y();
-	      this_xyz[2] = pPart.Position(i_s).Z();
-	      fstepPositions.push_back(this_xyz);
-	      fstepTimes.push_back(pPart.Position(i_s).T());
-	    }
+              this_xyz.clear();
+              this_xyz.resize(3);
+              this_xyz[0] = pPart.Position(i_s).X();
+              this_xyz[1] = pPart.Position(i_s).Y();
+              this_xyz[2] = pPart.Position(i_s).Z();
+              fstepPositions.push_back(this_xyz);
+              fstepTimes.push_back(pPart.Position(i_s).T());
+            }
             //filling the tree per track
             fLightAnalysisTree->Fill();
           }
-	}
+        }
       }
      }
     }
@@ -591,8 +591,8 @@ namespace opdet {
       //art::Handle< std::vector<sim::SimPhotonsLite> > photonHandle;
       //evt.getByLabel(mod, photonHandle);
 
-	// Loop over direct/reflected photons
-	for (auto const& ph_handle: photon_handles) {
+        // Loop over direct/reflected photons
+        for (auto const& ph_handle: photon_handles) {
           // Do some checking before we proceed
           if (!ph_handle.isValid()) continue;
           if (ph_handle.provenance()->moduleLabel() != mod) continue;   //not the most efficient way of doing this, but preserves the logic of the module. Andrzej
@@ -620,17 +620,17 @@ namespace opdet {
           //Reset Counters
           fCountOpDetAll=0;
           fCountOpDetDetected=0;
-	  fCountOpDetReflDetected=0;
+          fCountOpDetReflDetected=0;
 
          for(auto it = PhotonsMap.begin(); it!= PhotonsMap.end(); it++)
            {
              // Calculate wavelength in nm
-	     if (Reflected) {
-		fWavelength = 450;
-	     }
-	     else {
-	     fWavelength= 128;   // original
-	     }
+             if (Reflected) {
+                fWavelength = 450;
+             }
+             else {
+             fWavelength= 128;   // original
+             }
 
              //Get arrival time from phot
              fTime= it->first;
@@ -642,24 +642,24 @@ namespace opdet {
                 fCountOpDetAll++;
                 if(fMakeAllPhotonsTree) fThePhotonTreeAll->Fill();
 
-		if(odresponse->detectedLite(fOpChannel))
+                if(odresponse->detectedLite(fOpChannel))
                 {
                   if(fMakeDetectedPhotonsTree) fThePhotonTreeDetected->Fill();
                   // direct light
-		  if (!Reflected){
-		    fCountOpDetDetected++;
-		  }
-		  else if (Reflected) {
-		    fCountOpDetReflDetected++;
-		  }
-		  if(fVerbosity > 3)
+                  if (!Reflected){
+                    fCountOpDetDetected++;
+                  }
+                  else if (Reflected) {
+                    fCountOpDetReflDetected++;
+                  }
+                  if(fVerbosity > 3)
                   std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 1 "<<std::endl;
                 }
                 else
-		  if(fVerbosity > 3)
-		  {
+                  if(fVerbosity > 3)
+                  {
                   std::cout<<"OpDetResponseInterface PerPhoton : Event "<<fEventID<<" OpChannel " <<fOpChannel << " Wavelength " << fWavelength << " Detected 0 "<<std::endl;
-		  }
+                  }
               }
             }
 

--- a/larana/OpticalDetector/SimPhotonCounter_module.cc
+++ b/larana/OpticalDetector/SimPhotonCounter_module.cc
@@ -292,27 +292,27 @@ namespace opdet {
     art::ServiceHandle<geo::Geometry const> geo;
 
     // get the MCtrue info of the particles
-    art::Handle< std::vector<simb::MCParticle> > mclistLARG4;
-    evt.getByLabel("largeant",mclistLARG4);
-    std::vector<simb::MCParticle> const& mcpartVec(*mclistLARG4);
+    std::vector<simb::MCParticle> const* mcpartVec = fLightAnalysisTree
+      ? evt.getPointerByLabel<std::vector<simb::MCParticle>>("largeant")
+      : nullptr;
 
     //-------------------------initializing light tree vectors------------------------
-    size_t maxNtracks = 1000;//mcpartVec.size(); --- { to be fixed soon! ]
-    //size_t maxNtracks = mcpartVec.size();
-    fSignals_vuv.clear();
-    fSignals_vuv.resize(maxNtracks);
-    fSignals_vis.clear();
-    fSignals_vis.resize(maxNtracks);
-    for(size_t itrack=0; itrack!=maxNtracks; itrack++) {
-      fSignals_vuv[itrack].resize(geo->NOpChannels());
-      fSignals_vis[itrack].resize(geo->NOpChannels());
-    }
+    std::vector<double> totalEnergy_track;
     fstepPositions.clear();
     fstepTimes.clear();
-    //-------------------------stimation of dedx per trackID------------------------
-    //get the list of particles from this event
-    std::vector<double> totalEnergy_track(maxNtracks, 0.);
-    if(fMakeLightAnalysisTree){
+    if (fMakeLightAnalysisTree) {
+      size_t maxNtracks = 1000U; // mcpartVec->size(); --- { to be fixed soon! ]
+      fSignals_vuv.clear();
+      fSignals_vuv.resize(maxNtracks);
+      fSignals_vis.clear();
+      fSignals_vis.resize(maxNtracks);
+      for(size_t itrack=0; itrack!=maxNtracks; itrack++) {
+        fSignals_vuv[itrack].resize(geo->NOpChannels());
+        fSignals_vis[itrack].resize(geo->NOpChannels());
+      }
+      totalEnergy_track.resize(maxNtracks, 0.);
+      //-------------------------stimation of dedx per trackID----------------------
+      //get the list of particles from this event
       const sim::ParticleList* plist = pi_serv? &(pi_serv->ParticleList()): nullptr;
 
       // loop over all sim::SimChannels in the event and make sure there are no
@@ -543,9 +543,8 @@ namespace opdet {
           std::vector<double> this_xyz;
 
           //loop over the particles
-          for(size_t i_p=0; i_p < mcpartVec.size(); i_p++){
+          for(simb::MCParticle const& pPart: *mcpartVec){
 
-	    const simb::MCParticle pPart = mcpartVec[i_p];
 	    if(pPart.Process() == "primary")
 	      fEnergy = pPart.E();
 


### PR DESCRIPTION
This pull request is twin of [larsim pull request #31](https://github.com/LArSoft/larsim/pull/31), of which it completes the features.
The motivation is described in that pull request.
New features introduced in `SimPhotonCounter` module:
* deal with events missing a `simb::MCParticle` collection, when that collection is effectively not needed;
* support for filling the library with information from `sim::SimPhotonsLite` instead of `sim::SimPhotons`

The whole photon library generation pattern is in need of a deep redesign, which is not attempted here.