### PR TITLE
Optical hit sliding window algorithm won't set hit end to inifinite

### DIFF
--- a/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
@@ -154,7 +154,8 @@ namespace pmtana {
         // If there's a pulse, end we where in in_post, end the previous pulse first
         if (in_post) {
           // Find were
-          _pulse.t_end = i - buffer_num_index - 1;
+          _pulse.t_end = static_cast<int>(i) - buffer_num_index;
+          if (_pulse.t_end > 0) --_pulse.t_end; // leave a gap, if we can
 
           // Register if width is acceptable
           if ((_pulse.t_end - _pulse.t_start) >= _min_width) _pulse_v.push_back(_pulse);


### PR DESCRIPTION
Bug fix for a corner case documented in ICARUS GitHub issue #94:
SBNSoftware/icaruscode#94.
Note that the branch is based on LArSoft `v09_09_00`.