### PR TITLE
Modify OpHit finder algorithms to save the StartTime/RiseTime

### DIFF
--- a/larana/OpticalDetector/CMakeLists.txt
+++ b/larana/OpticalDetector/CMakeLists.txt
@@ -169,7 +169,7 @@ cet_build_plugin(OpFlashSimpleAna art::EDAnalyzer
   art_root_io::TFileService_service
   art::Framework_Principal
   art::Framework_Services_Registry
-  fhiclcpp::fhiclcpp    
+  fhiclcpp::fhiclcpp
   ROOT::Tree
 )
 

--- a/larana/OpticalDetector/OpHitFinder/AlgoCFD.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoCFD.cxx
@@ -36,13 +36,7 @@ namespace pmtana{
     _start_thresh     = pset.get<double>("StartThresh");
     _end_thresh       = pset.get<double>("EndThresh");
 
-    if(risetimecalculator!=nullptr){
-      _risetime_calc_ptr = std::move(risetimecalculator);
-      _compute_risetime=true;
-    }
-    else{
-      _compute_risetime=false;
-    }
+    _risetime_calc_ptr = std::move(risetimecalculator);
 
     Reset();
 
@@ -175,12 +169,12 @@ namespace pmtana{
 	  if ( a > 0 ) _pulse.area += a;
 	}
 
-	if(_compute_risetime)
+	if(_risetime_calc_ptr)
 	  _pulse.t_rise = _risetime_calc_ptr->RiseTime(
 			    {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
 			    {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},
 			    true);
-	
+
 	_pulse_v.push_back(_pulse);
       }
 

--- a/larana/OpticalDetector/OpHitFinder/AlgoCFD.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoCFD.cxx
@@ -21,8 +21,9 @@ namespace pmtana{
 
   //*********************************************************************
   AlgoCFD::AlgoCFD(const fhicl::ParameterSet &pset,
-  //AlgoCFD::AlgoCFD(const ::fcllite::PSet &pset,
-		   const std::string name)
+    std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator,
+    //AlgoCFD::AlgoCFD(const ::fcllite::PSet &pset,
+    const std::string name)
     : PMTPulseRecoBase(name)
       //*********************************************************************
   {
@@ -34,6 +35,14 @@ namespace pmtana{
     _peak_thresh      = pset.get<double>("PeakThresh");
     _start_thresh     = pset.get<double>("StartThresh");
     _end_thresh       = pset.get<double>("EndThresh");
+
+    if(risetimecalculator!=nullptr){
+      _risetime_calc_ptr = std::move(risetimecalculator);
+      _compute_risetime=true;
+    }
+    else{
+      _compute_risetime=false;
+    }
 
     Reset();
 
@@ -166,6 +175,12 @@ namespace pmtana{
 	  if ( a > 0 ) _pulse.area += a;
 	}
 
+	if(_compute_risetime)
+	  _pulse.t_rise = _risetime_calc_ptr->RiseTime(
+			    {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
+			    {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},
+			    true);
+	
 	_pulse_v.push_back(_pulse);
       }
 

--- a/larana/OpticalDetector/OpHitFinder/AlgoCFD.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoCFD.h
@@ -40,8 +40,10 @@ namespace pmtana
     AlgoCFD(const std::string name="CFD");
 
     /// Alternative ctor
-    AlgoCFD(const fhicl::ParameterSet &pset,const std::string name="CFD");
-    //AlgoCFD(const ::fcllite::PSet &pset,const std::string name="CFD");
+    AlgoCFD(const fhicl::ParameterSet &pset,
+       std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator,
+       const std::string name="CFD");
+       //AlgoCFD(const ::fcllite::PSet &pset,const std::string name="CFD");
 
     /// Implementation of AlgoCFD::reset() method
     void Reset();

--- a/larana/OpticalDetector/OpHitFinder/AlgoCFD.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoCFD.h
@@ -41,7 +41,7 @@ namespace pmtana
 
     /// Alternative ctor
     AlgoCFD(const fhicl::ParameterSet &pset,
-       std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator,
+       std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator=nullptr,
        const std::string name="CFD");
        //AlgoCFD(const ::fcllite::PSet &pset,const std::string name="CFD");
 

--- a/larana/OpticalDetector/OpHitFinder/AlgoFixedWindow.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoFixedWindow.cxx
@@ -29,13 +29,7 @@ namespace pmtana{
     : PMTPulseRecoBase(name)
   //****************************************************************************************
   {
-    if(risetimecalculator!=nullptr){
-      _risetime_calc_ptr = std::move(risetimecalculator);
-      _compute_risetime=true;
-    }
-    else{
-      _compute_risetime=false;
-    }
+    _risetime_calc_ptr = std::move(risetimecalculator);
 
     Reset();
 
@@ -92,7 +86,7 @@ namespace pmtana{
 
     _pulse_v[0].area = _pulse_v[0].area - ( _pulse_v[0].t_end - _pulse_v[0].t_start + 1) * mean_v.front();
 
-    if(_compute_risetime)
+    if(_risetime_calc_ptr)
       _pulse_v[0].t_rise = _risetime_calc_ptr->RiseTime(
                         {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
                         {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},

--- a/larana/OpticalDetector/OpHitFinder/AlgoFixedWindow.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoFixedWindow.cxx
@@ -23,11 +23,20 @@ namespace pmtana{
 
   //****************************************************************************************
   AlgoFixedWindow::AlgoFixedWindow(const fhicl::ParameterSet &pset,
-  //AlgoFixedWindow::AlgoFixedWindow(const ::fcllite::PSet& pset,
-				   const std::string name)
+    std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator,
+    //AlgoFixedWindow::AlgoFixedWindow(const ::fcllite::PSet& pset,
+		const std::string name)
     : PMTPulseRecoBase(name)
   //****************************************************************************************
   {
+    if(risetimecalculator!=nullptr){
+      _risetime_calc_ptr = std::move(risetimecalculator);
+      _compute_risetime=true;
+    }
+    else{
+      _compute_risetime=false;
+    }
+
     Reset();
 
     _index_start = pset.get<size_t>("StartIndex");
@@ -82,6 +91,12 @@ namespace pmtana{
     PMTPulseRecoBase::Integral(wf, _pulse_v[0].area, _index_start, _pulse_v[0].t_end);
 
     _pulse_v[0].area = _pulse_v[0].area - ( _pulse_v[0].t_end - _pulse_v[0].t_start + 1) * mean_v.front();
+
+    if(_compute_risetime)
+      _pulse_v[0].t_rise = _risetime_calc_ptr->RiseTime(
+                        {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
+                        {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},
+                        true);
 
     return true;
 

--- a/larana/OpticalDetector/OpHitFinder/AlgoFixedWindow.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoFixedWindow.h
@@ -42,7 +42,9 @@ namespace pmtana
     AlgoFixedWindow(const std::string name="FixedWindow");
 
     /// Alternative ctor
-    AlgoFixedWindow(const fhicl::ParameterSet &pset,const std::string name="FixedWindow");
+    AlgoFixedWindow(const fhicl::ParameterSet &pset,
+      std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator,
+      const std::string name="FixedWindow");
     //AlgoFixedWindow(const ::fcllite::PSet &pset,const std::string name="FixedWindow");
 
     /// Implementation of AlgoFixedWindow::reset() method

--- a/larana/OpticalDetector/OpHitFinder/AlgoFixedWindow.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoFixedWindow.h
@@ -43,7 +43,7 @@ namespace pmtana
 
     /// Alternative ctor
     AlgoFixedWindow(const fhicl::ParameterSet &pset,
-      std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator,
+      std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator=nullptr,
       const std::string name="FixedWindow");
     //AlgoFixedWindow(const ::fcllite::PSet &pset,const std::string name="FixedWindow");
 

--- a/larana/OpticalDetector/OpHitFinder/AlgoSiPM.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSiPM.cxx
@@ -9,7 +9,9 @@
 namespace pmtana {
 
   //---------------------------------------------------------------------------
-  AlgoSiPM::AlgoSiPM(const fhicl::ParameterSet &pset,const std::string name)
+  AlgoSiPM::AlgoSiPM(const fhicl::ParameterSet &pset,
+    std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator,
+    const std::string name)
     : PMTPulseRecoBase(name)
   {
 
@@ -17,6 +19,14 @@ namespace pmtana {
     _min_width = pset.get< float >("MinWidth"       );
     _2nd_thres = pset.get< float >("SecondThreshold");
     _pedestal  = pset.get< float >("Pedestal"       );
+
+    if(risetimecalculator!=nullptr){
+      _risetime_calc_ptr = std::move(risetimecalculator);
+      _compute_risetime=true;
+    }
+    else{
+      std::cout<<" In AlgoSlidingWindow-.-. we have a null ptr\n";
+    }
 
 //    _nsigma = 5;
 
@@ -73,6 +83,12 @@ namespace pmtana {
         _pulse.t_end = counter - 1;
         if (record_hit && ((_pulse.t_end - _pulse.t_start) >= _min_width))
         {
+          if(_compute_risetime)
+            _pulse.t_rise = _risetime_calc_ptr->RiseTime(
+                              {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
+                              {ped_mean.begin()+_pulse.t_start, ped_mean.begin()+_pulse.t_end},
+                              true);
+
           _pulse_v.push_back(_pulse);
           record_hit = false;
         }
@@ -93,7 +109,7 @@ namespace pmtana {
 
           // Found a new maximum
           _pulse.peak  = (double(value) - double(pedestal));
-          _pulse.t_max = counter; 
+          _pulse.t_max = counter;
 
         }
         else if (!first_found)
@@ -113,6 +129,12 @@ namespace pmtana {
       _pulse.t_end = counter - 1;
       if (record_hit && ((_pulse.t_end - _pulse.t_start) >= _min_width))
       {
+        if(_compute_risetime)
+          _pulse.t_rise = _risetime_calc_ptr->RiseTime(
+                            {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
+                            {ped_mean.begin()+_pulse.t_start, ped_mean.begin()+_pulse.t_end},
+                            true);
+
         _pulse_v.push_back(_pulse);
         record_hit = false;
       }

--- a/larana/OpticalDetector/OpHitFinder/AlgoSiPM.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSiPM.cxx
@@ -20,13 +20,7 @@ namespace pmtana {
     _2nd_thres = pset.get< float >("SecondThreshold");
     _pedestal  = pset.get< float >("Pedestal"       );
 
-    if(risetimecalculator!=nullptr){
-      _risetime_calc_ptr = std::move(risetimecalculator);
-      _compute_risetime=true;
-    }
-    else{
-      std::cout<<" In AlgoSlidingWindow-.-. we have a null ptr\n";
-    }
+    _risetime_calc_ptr = std::move(risetimecalculator);
 
 //    _nsigma = 5;
 
@@ -83,7 +77,7 @@ namespace pmtana {
         _pulse.t_end = counter - 1;
         if (record_hit && ((_pulse.t_end - _pulse.t_start) >= _min_width))
         {
-          if(_compute_risetime)
+          if(_risetime_calc_ptr)
             _pulse.t_rise = _risetime_calc_ptr->RiseTime(
                               {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
                               {ped_mean.begin()+_pulse.t_start, ped_mean.begin()+_pulse.t_end},
@@ -129,7 +123,7 @@ namespace pmtana {
       _pulse.t_end = counter - 1;
       if (record_hit && ((_pulse.t_end - _pulse.t_start) >= _min_width))
       {
-        if(_compute_risetime)
+        if(_risetime_calc_ptr)
           _pulse.t_rise = _risetime_calc_ptr->RiseTime(
                             {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
                             {ped_mean.begin()+_pulse.t_start, ped_mean.begin()+_pulse.t_end},

--- a/larana/OpticalDetector/OpHitFinder/AlgoSiPM.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSiPM.h
@@ -24,7 +24,7 @@ namespace pmtana {
   public:
 
     AlgoSiPM(const fhicl::ParameterSet &pset,
-        std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator,
+        std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator=nullptr,
         const std::string name="AlgoSiPM");
 
     // Implementation of PMTPulseRecoBase::Reset() method

--- a/larana/OpticalDetector/OpHitFinder/AlgoSiPM.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSiPM.h
@@ -23,7 +23,9 @@ namespace pmtana {
 
   public:
 
-    AlgoSiPM(const fhicl::ParameterSet &pset,const std::string name="AlgoSiPM");
+    AlgoSiPM(const fhicl::ParameterSet &pset,
+        std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator,
+        const std::string name="AlgoSiPM");
 
     // Implementation of PMTPulseRecoBase::Reset() method
     void Reset();

--- a/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
@@ -8,6 +8,8 @@
 
 #include "AlgoSlidingWindow.h"
 
+#include "art/Utilities/make_tool.h"
+
 namespace pmtana {
 
   //*********************************************************************

--- a/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
@@ -46,13 +46,7 @@ namespace pmtana {
 
     _min_width = pset.get<size_t>("MinPulseWidth", 0);
 
-    if(risetimecalculator!=nullptr){
-      _risetime_calc_ptr = std::move(risetimecalculator);
-      _compute_risetime=true;
-    }
-    else{
-      _compute_risetime=false;
-    }
+    _risetime_calc_ptr = std::move(risetimecalculator);
 
     Reset();
   }
@@ -124,7 +118,7 @@ namespace pmtana {
 
           // Register if width is acceptable
           if ((_pulse.t_end - _pulse.t_start) >= _min_width) {
-            if(_compute_risetime)
+            if(_risetime_calc_ptr)
               _pulse.t_rise = _risetime_calc_ptr->RiseTime(
                                 {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
                                 {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},
@@ -176,7 +170,7 @@ namespace pmtana {
 
           // Register if width is acceptable
           if ((_pulse.t_end - _pulse.t_start) >= _min_width) {
-            if(_compute_risetime)
+            if(_risetime_calc_ptr)
               _pulse.t_rise = _risetime_calc_ptr->RiseTime(
                                 {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
                                 {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},
@@ -243,7 +237,7 @@ namespace pmtana {
 
         // Register if width is acceptable
         if ((_pulse.t_end - _pulse.t_start) >= _min_width) {
-          if(_compute_risetime)
+          if(_risetime_calc_ptr)
             _pulse.t_rise = _risetime_calc_ptr->RiseTime(
                               {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
                               {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},
@@ -292,7 +286,7 @@ namespace pmtana {
 
       // Register if width is acceptable
       if ((_pulse.t_end - _pulse.t_start) >= _min_width) {
-        if(_compute_risetime)
+        if(_risetime_calc_ptr)
           _pulse.t_rise = _risetime_calc_ptr->RiseTime(
                             {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
                             {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},

--- a/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.cxx
@@ -45,6 +45,12 @@ namespace pmtana {
 
     _min_width = pset.get<size_t>("MinPulseWidth", 0);
 
+    _compute_risetime = pset.get<bool>("ComputeRiseTime", false);
+
+    if(_compute_risetime)
+      _risetime_calc_ptr = art::make_tool<pmtana::RiseTimeCalculatorBase>(
+                            pset.get< fhicl::ParameterSet >("RiseTimeCalculator") );
+
     Reset();
   }
 
@@ -114,7 +120,15 @@ namespace pmtana {
           _pulse.t_end = i - 1;
 
           // Register if width is acceptable
-          if ((_pulse.t_end - _pulse.t_start) >= _min_width) _pulse_v.push_back(_pulse);
+          if ((_pulse.t_end - _pulse.t_start) >= _min_width) {
+            if(_compute_risetime)
+              _pulse.t_rise = _pulse.t_start + _risetime_calc_ptr->RiseTime(
+                                {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
+                                {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},
+                                _positive);
+
+            _pulse_v.push_back(_pulse);
+          }
 
           _pulse.reset_param();
 
@@ -158,7 +172,15 @@ namespace pmtana {
           if (_pulse.t_end > 0) --_pulse.t_end; // leave a gap, if we can
 
           // Register if width is acceptable
-          if ((_pulse.t_end - _pulse.t_start) >= _min_width) _pulse_v.push_back(_pulse);
+          if ((_pulse.t_end - _pulse.t_start) >= _min_width) {
+            if(_compute_risetime)
+              _pulse.t_rise = _pulse.t_start + _risetime_calc_ptr->RiseTime(
+                                {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
+                                {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},
+                                _positive);
+
+            _pulse_v.push_back(_pulse);
+          }
 
           _pulse.reset_param();
 
@@ -217,7 +239,15 @@ namespace pmtana {
         _pulse.t_end = i - 1;
 
         // Register if width is acceptable
-        if ((_pulse.t_end - _pulse.t_start) >= _min_width) _pulse_v.push_back(_pulse);
+        if ((_pulse.t_end - _pulse.t_start) >= _min_width) {
+          if(_compute_risetime)
+            _pulse.t_rise = _pulse.t_start + _risetime_calc_ptr->RiseTime(
+                              {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
+                              {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},
+                              _positive);
+
+          _pulse_v.push_back(_pulse);
+        }
 
         if (_verbose)
           std::cout << "\033[93mPulse End\033[00m: "
@@ -258,7 +288,13 @@ namespace pmtana {
       _pulse.t_end = wf.size() - 1;
 
       // Register if width is acceptable
-      if ((_pulse.t_end - _pulse.t_start) >= _min_width) _pulse_v.push_back(_pulse);
+      if ((_pulse.t_end - _pulse.t_start) >= _min_width) {
+        if(_compute_risetime)
+          _risetime_calc_ptr->RiseTime( {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
+                                        {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},
+                                        _positive);
+        _pulse_v.push_back(_pulse);
+      }
 
       _pulse.reset_param();
     }

--- a/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.h
@@ -20,8 +20,6 @@ namespace fhicl { class ParameterSet; }
 
 #include "larana/OpticalDetector/OpHitFinder/OpticalRecoTypes.h"
 
-#include "art/Utilities/make_tool.h"
-
 #include <string>
 
 namespace pmtana

--- a/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.h
@@ -37,7 +37,8 @@ namespace pmtana
     AlgoSlidingWindow(const std::string name="SlidingWindow");
 
     /// Alternative ctor
-    AlgoSlidingWindow(const fhicl::ParameterSet &pset,const std::string name="SlidingWindow");
+    AlgoSlidingWindow(const fhicl::ParameterSet &pset,
+      std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator, const std::string name="SlidingWindow");
     //AlgoSlidingWindow(const ::fcllite::PSet &pset,const std::string name="SlidingWindow");
 
     /// Implementation of AlgoSlidingWindow::reset() method
@@ -64,8 +65,6 @@ namespace pmtana
     bool _verbose;
     size_t _num_presample, _num_postsample;
 
-    // Tool for rise time calculation
-    bool _compute_risetime;
   };
 
 }

--- a/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.h
@@ -20,6 +20,8 @@ namespace fhicl { class ParameterSet; }
 
 #include "larana/OpticalDetector/OpHitFinder/OpticalRecoTypes.h"
 
+#include "art/Utilities/make_tool.h"
+
 #include <string>
 
 namespace pmtana
@@ -63,6 +65,9 @@ namespace pmtana
     float _nsigma, _tail_nsigma, _end_nsigma;
     bool _verbose;
     size_t _num_presample, _num_postsample;
+
+    // Tool for rise time calculation
+    bool _compute_risetime;
   };
 
 }

--- a/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.h
@@ -38,7 +38,8 @@ namespace pmtana
 
     /// Alternative ctor
     AlgoSlidingWindow(const fhicl::ParameterSet &pset,
-      std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator, const std::string name="SlidingWindow");
+      std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator=nullptr,
+      const std::string name="SlidingWindow");
     //AlgoSlidingWindow(const ::fcllite::PSet &pset,const std::string name="SlidingWindow");
 
     /// Implementation of AlgoSlidingWindow::reset() method

--- a/larana/OpticalDetector/OpHitFinder/AlgoThreshold.cxx
+++ b/larana/OpticalDetector/OpHitFinder/AlgoThreshold.cxx
@@ -36,13 +36,7 @@ namespace pmtana{
     _nsigma_start = pset.get<double>("NSigmaThresholdStart");
     _nsigma_end   = pset.get<double>("NSigmaThresholdEnd");
 
-    if(risetimecalculator!=nullptr){
-      _risetime_calc_ptr = std::move(risetimecalculator);
-      _compute_risetime=true;
-    }
-    else{
-      _compute_risetime=false;
-    }
+    _risetime_calc_ptr = std::move(risetimecalculator);
 
     Reset();
 
@@ -106,7 +100,7 @@ namespace pmtana{
 	//vic: i move t_start forward one, this helps with tail
 	_pulse.t_end = counter < wf.size()  ? counter : counter - 1;
 
-  if(_compute_risetime)
+  if(_risetime_calc_ptr)
     _pulse.t_rise = _risetime_calc_ptr->RiseTime(
                       {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
                       {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},
@@ -150,7 +144,7 @@ namespace pmtana{
 
       _pulse.t_end = counter - 1;
 
-      if(_compute_risetime)
+      if(_risetime_calc_ptr)
         _pulse.t_rise = _risetime_calc_ptr->RiseTime(
                           {wf.begin()+_pulse.t_start, wf.begin()+_pulse.t_end},
                           {mean_v.begin()+_pulse.t_start, mean_v.begin()+_pulse.t_end},

--- a/larana/OpticalDetector/OpHitFinder/AlgoThreshold.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoThreshold.h
@@ -41,7 +41,8 @@ namespace pmtana
 
     /// Alternative constructor
     AlgoThreshold(const fhicl::ParameterSet &pset,
-      std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator, const std::string name="AlgoThreshold");
+      std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator=nullptr,
+      const std::string name="AlgoThreshold");
     //AlgoThreshold(const ::fcllite::PSet &pset,const std::string name="AlgoThreshold");
 
     /// Implementation of AlgoThreshold::reset() method

--- a/larana/OpticalDetector/OpHitFinder/AlgoThreshold.h
+++ b/larana/OpticalDetector/OpHitFinder/AlgoThreshold.h
@@ -40,7 +40,8 @@ namespace pmtana
     AlgoThreshold(const std::string name="AlgoThreshold");
 
     /// Alternative constructor
-    AlgoThreshold(const fhicl::ParameterSet &pset,const std::string name="AlgoThreshold");
+    AlgoThreshold(const fhicl::ParameterSet &pset,
+      std::unique_ptr<pmtana::RiseTimeCalculatorBase> risetimecalculator, const std::string name="AlgoThreshold");
     //AlgoThreshold(const ::fcllite::PSet &pset,const std::string name="AlgoThreshold");
 
     /// Implementation of AlgoThreshold::reset() method

--- a/larana/OpticalDetector/OpHitFinder/CMakeLists.txt
+++ b/larana/OpticalDetector/OpHitFinder/CMakeLists.txt
@@ -21,7 +21,6 @@ cet_make_library(SOURCE
   lardataobj::RawData
   lardataobj::RecoBase
   PRIVATE
-  art_plugin_support::toolMaker
   larreco::PhotonCalibrator
   lardataalg::DetectorInfo
   larcorealg::Geometry

--- a/larana/OpticalDetector/OpHitFinder/CMakeLists.txt
+++ b/larana/OpticalDetector/OpHitFinder/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(RiseTimeTools)
+
 cet_make_library(SOURCE
   AlgoCFD.cxx
   AlgoFixedWindow.cxx
@@ -19,6 +21,7 @@ cet_make_library(SOURCE
   lardataobj::RawData
   lardataobj::RecoBase
   PRIVATE
+  art_plugin_support::toolMaker
   larreco::PhotonCalibrator
   lardataalg::DetectorInfo
   larcorealg::Geometry

--- a/larana/OpticalDetector/OpHitFinder/OpHitAlg.cxx
+++ b/larana/OpticalDetector/OpHitFinder/OpHitAlg.cxx
@@ -56,7 +56,7 @@ namespace opdet {
       const double timeStamp = waveform.TimeStamp();
 
       for (auto const& pulse : pulses)
-        ConstructHit(hitThreshold, channel, timeStamp, pulse, hitVector, clocksData, calibrator);
+        ConstructHit(hitThreshold, channel, timeStamp, pulse, hitVector, clocksData, calibrator, use_start_time);
     }
   }
 

--- a/larana/OpticalDetector/OpHitFinder/OpHitAlg.cxx
+++ b/larana/OpticalDetector/OpHitFinder/OpHitAlg.cxx
@@ -34,7 +34,8 @@ namespace opdet {
                geo::GeometryCore const& geometry,
                float hitThreshold,
                detinfo::DetectorClocksData const& clocksData,
-               calib::IPhotonCalibrator const& calibrator)
+               calib::IPhotonCalibrator const& calibrator,
+               bool use_start_time)
   {
 
     for (auto const& waveform : opDetWaveformVector) {
@@ -67,18 +68,19 @@ namespace opdet {
                pmtana::pulse_param const& pulse,
                std::vector<recob::OpHit>& hitVector,
                detinfo::DetectorClocksData const& clocksData,
-               calib::IPhotonCalibrator const& calibrator)
+               calib::IPhotonCalibrator const& calibrator,
+               bool use_start_time)
   {
 
     if (pulse.peak < hitThreshold) return;
 
-    double absTime = timeStamp + clocksData.OpticalClock().TickPeriod() * pulse.t_max;
+    double absTime = timeStamp + clocksData.OpticalClock().TickPeriod() * (use_start_time ? pulse.t_start : pulse.t_max);
 
     double relTime = absTime - clocksData.TriggerTime();
 
     double startTime = timeStamp + clocksData.OpticalClock().TickPeriod() * pulse.t_start - clocksData.TriggerTime();
 
-    double riseTime = timeStamp + clocksData.OpticalClock().TickPeriod() * pulse.t_rise - clocksData.TriggerTime();
+    double riseTime = clocksData.OpticalClock().TickPeriod() * pulse.t_rise;
 
     int frame = clocksData.OpticalClock().Frame(timeStamp);
 

--- a/larana/OpticalDetector/OpHitFinder/OpHitAlg.h
+++ b/larana/OpticalDetector/OpHitFinder/OpHitAlg.h
@@ -30,7 +30,8 @@ namespace opdet {
                     geo::GeometryCore const&,
                     float,
                     detinfo::DetectorClocksData const&,
-                    calib::IPhotonCalibrator const&);
+                    calib::IPhotonCalibrator const&,
+                    bool use_start_time=false);
 
   void ConstructHit(float,
                     int,
@@ -38,7 +39,8 @@ namespace opdet {
                     pmtana::pulse_param const&,
                     std::vector<recob::OpHit>&,
                     detinfo::DetectorClocksData const&,
-                    calib::IPhotonCalibrator const&);
+                    calib::IPhotonCalibrator const&,
+                    bool use_start_time=false);
 
 } // End opdet namespace
 

--- a/larana/OpticalDetector/OpHitFinder/OpHitAlg.h
+++ b/larana/OpticalDetector/OpHitFinder/OpHitAlg.h
@@ -30,8 +30,7 @@ namespace opdet {
                     geo::GeometryCore const&,
                     float,
                     detinfo::DetectorClocksData const&,
-                    calib::IPhotonCalibrator const&,
-		    bool use_start_time=false);
+                    calib::IPhotonCalibrator const&);
 
   void ConstructHit(float,
                     int,
@@ -39,8 +38,7 @@ namespace opdet {
                     pmtana::pulse_param const&,
                     std::vector<recob::OpHit>&,
                     detinfo::DetectorClocksData const&,
-                    calib::IPhotonCalibrator const&,
-		    bool use_start_time=false);
+                    calib::IPhotonCalibrator const&);
 
 } // End opdet namespace
 

--- a/larana/OpticalDetector/OpHitFinder/PMTPulseRecoBase.h
+++ b/larana/OpticalDetector/OpHitFinder/PMTPulseRecoBase.h
@@ -20,6 +20,10 @@
 #include <vector>
 
 #include "OpticalRecoTypes.h"
+#include "larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeCalculatorBase.h"
+
+#include <memory>
+
 
 namespace pmtana
 {
@@ -27,7 +31,7 @@ namespace pmtana
   struct pulse_param{
   public:
     double peak, area, ped_mean, ped_sigma;
-    double t_start, t_max, t_end;
+    double t_start, t_max, t_end, t_rise;
 
     //for vic
     double t_cfdcross;
@@ -40,7 +44,7 @@ namespace pmtana
       area = 0;
       peak = -1;
       ped_mean = ped_sigma = -1;
-      t_start = t_max = t_end = -1;
+      t_start = t_max = t_end = t_rise = -1;
       t_cfdcross = -1;
     }
 
@@ -120,6 +124,9 @@ namespace pmtana
 
     /// A subject pulse_param object to be filled with the last reconstructed pulse parameters
     pulse_param _pulse;
+
+    /// Tool for rise time calculation
+    std::unique_ptr<pmtana::RiseTimeCalculatorBase> _risetime_calc_ptr;
 
   protected:
 

--- a/larana/OpticalDetector/OpHitFinder/PMTPulseRecoBase.h
+++ b/larana/OpticalDetector/OpHitFinder/PMTPulseRecoBase.h
@@ -126,7 +126,6 @@ namespace pmtana
     pulse_param _pulse;
 
     /// Tool for rise time calculation
-    bool _compute_risetime;
     std::unique_ptr<pmtana::RiseTimeCalculatorBase>  _risetime_calc_ptr = nullptr;
 
   protected:

--- a/larana/OpticalDetector/OpHitFinder/PMTPulseRecoBase.h
+++ b/larana/OpticalDetector/OpHitFinder/PMTPulseRecoBase.h
@@ -126,7 +126,8 @@ namespace pmtana
     pulse_param _pulse;
 
     /// Tool for rise time calculation
-    std::unique_ptr<pmtana::RiseTimeCalculatorBase> _risetime_calc_ptr;
+    bool _compute_risetime;
+    std::unique_ptr<pmtana::RiseTimeCalculatorBase>  _risetime_calc_ptr = nullptr;
 
   protected:
 

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/CMakeLists.txt
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/CMakeLists.txt
@@ -1,0 +1,21 @@
+cet_enable_asserts()
+
+cet_make_library(LIBRARY_NAME RiseTimeCalculatorTool INTERFACE
+  SOURCE RiseTimeCalculatorBase.h
+)
+
+cet_write_plugin_builder(lar::RiseTimeCalculatorTool art::tool Modules
+  INSTALL_BUILDER
+)
+
+include(lar::RiseTimeCalculatorTool)
+
+cet_build_plugin(RiseTimeThreshold lar::RiseTimeCalculatorTool
+  LIBRARIES PRIVATE
+  fhiclcpp::fhiclcpp
+)
+
+
+install_headers()
+install_source()
+install_fhicl()

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/CMakeLists.txt
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/CMakeLists.txt
@@ -6,6 +6,8 @@ cet_make_library(LIBRARY_NAME RiseTimeCalculatorTool INTERFACE
 
 cet_write_plugin_builder(lar::RiseTimeCalculatorTool art::tool Modules
   INSTALL_BUILDER
+  LIBRARIES CONDITIONAL
+  larana::RiseTimeCalculatorTool
 )
 
 include(lar::RiseTimeCalculatorTool)

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeCalculatorBase.h
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeCalculatorBase.h
@@ -22,7 +22,9 @@ namespace pmtana
     virtual ~RiseTimeCalculatorBase() noexcept = default;
 
     // Method to calculate the OpFlash t0
-    virtual double RiseTime(const pmtana::Waveform_t& wf_pulse, const pmtana::PedestalMean_t& ped_pulse, bool _positive) = 0;
+    virtual double RiseTime(const pmtana::Waveform_t& wf_pulse,
+                            const pmtana::PedestalMean_t& ped_pulse,
+                            bool _positive) const = 0;
 
   private:
 

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeCalculatorBase.h
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeCalculatorBase.h
@@ -1,0 +1,32 @@
+/**
+ * \file RiseTimeCalculatorBase.h
+ *
+ *
+ * \brief Interfacce class for a tool to calculate the pulse rise time
+ *
+ * @author Fran Nicolas, June 2022
+ */
+
+
+#ifndef RISETIMECALCULATORBASE_H
+#define RISETIMECALCULATORBASE_H
+
+#include "larana/OpticalDetector/OpHitFinder/OpticalRecoTypes.h"
+
+namespace pmtana
+{
+  class RiseTimeCalculatorBase{
+
+  public:
+    // Default destructor
+    virtual ~RiseTimeCalculatorBase() noexcept = default;
+
+    // Method to calculate the OpFlash t0
+    virtual double RiseTime(const pmtana::Waveform_t& wf_pulse, const pmtana::PedestalMean_t& ped_pulse, bool _positive) = 0;
+
+  private:
+
+  };
+}
+
+#endif

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
@@ -1,0 +1,73 @@
+/**
+ * \file RiseTimeThreshold_tool.cc
+ *
+ * \brief Rise time is defined as the time slot in which the pulse
+ * goes above a certain fraction of the maximum ADC peak value
+ * given by the "PeakRatio" fhicl parameter
+ *
+ * @author Fran Nicolas, June 2022
+ */
+
+#include "fhiclcpp/types/Atom.h"
+#include "art/Utilities/ToolMacros.h"
+#include "art/Utilities/ToolConfigTable.h"
+
+#include "RiseTimeCalculatorBase.h"
+
+namespace pmtana{
+
+  class RiseTimeThreshold : RiseTimeCalculatorBase
+  {
+
+  public:
+
+    //Configuration parameters
+    struct Config {
+
+      fhicl::Atom<double> PeakRatio {
+        fhicl::Name("PeakRatio")
+      };
+
+    };
+
+    // Default constructor
+    explicit RiseTimeThreshold(art::ToolConfigTable<Config> const& config);
+
+    // Method to calculate the OpFlash t0
+    double RiseTime(const pmtana::Waveform_t& wf_pulse, const pmtana::PedestalMean_t& ped_pulse, bool _positive);
+
+  private:
+
+    double fPeakRatio;
+
+  };
+
+  RiseTimeThreshold::RiseTimeThreshold(art::ToolConfigTable<Config> const& config)
+    : fPeakRatio { config().PeakRatio() }
+  {
+  }
+
+  double RiseTimeThreshold::RiseTime(const pmtana::Waveform_t& wf_pulse, const pmtana::PedestalMean_t& ped_pulse, bool _positive){
+
+    // Pedestal-subtracted pulse
+    std::vector<double> wf_aux (ped_pulse);
+    if(_positive){
+      for(size_t ix=0; ix<wf_aux.size(); ix++){
+        wf_aux[ix]=((double)wf_pulse[ix])-wf_aux[ix];
+      }
+    }
+    else{
+      for(size_t ix=0; ix<wf_aux.size(); ix++){
+        wf_aux[ix]=wf_aux[ix]-((double)wf_pulse[ix]);
+      }
+    }
+
+    auto it_max = max_element(wf_aux.begin(), wf_aux.end());
+    size_t rise = std::lower_bound( wf_aux.begin(), it_max, fPeakRatio*(*it_max) ) - wf_aux.begin();
+
+    return rise;
+  }
+
+}
+
+DEFINE_ART_CLASS_TOOL(pmtana::RiseTimeThreshold)

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
@@ -34,7 +34,9 @@ namespace pmtana{
     explicit RiseTimeThreshold(art::ToolConfigTable<Config> const& config);
 
     // Method to calculate the OpFlash t0
-    double RiseTime(const pmtana::Waveform_t& wf_pulse, const pmtana::PedestalMean_t& ped_pulse, bool _positive);
+    double RiseTime(const pmtana::Waveform_t& wf_pulse,
+                    const pmtana::PedestalMean_t& ped_pulse,
+                    bool _positive) const override;
 
   private:
 
@@ -47,7 +49,9 @@ namespace pmtana{
   {
   }
 
-  double RiseTimeThreshold::RiseTime(const pmtana::Waveform_t& wf_pulse, const pmtana::PedestalMean_t& ped_pulse, bool _positive){
+  double RiseTimeThreshold::RiseTime(const pmtana::Waveform_t& wf_pulse,
+                                     const pmtana::PedestalMean_t& ped_pulse,
+                                     bool _positive) const{
 
     // Pedestal-subtracted pulse
     std::vector<double> wf_aux (ped_pulse);

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/risetimecalculator_tool.fcl
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/risetimecalculator_tool.fcl
@@ -1,0 +1,10 @@
+BEGIN_PROLOG
+
+RiseTimeThreshold:
+{
+    tool_type: RiseTimeThreshold
+    PeakRatio:         0.2
+}
+
+
+END_PROLOG

--- a/larana/OpticalDetector/OpHitFinder_module.cc
+++ b/larana/OpticalDetector/OpHitFinder_module.cc
@@ -35,6 +35,7 @@
 #include "art/Framework/Core/ModuleMacros.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
+#include "art/Utilities/make_tool.h"
 #include "canvas/Utilities/Exception.h"
 #include "fhiclcpp/ParameterSet.h"
 
@@ -73,6 +74,7 @@ namespace opdet {
 
     Float_t fHitThreshold;
     unsigned int fMaxOpChannel;
+    bool fUseStartTime;
 
     calib::IPhotonCalibrator const* fCalib = nullptr;
   };
@@ -93,6 +95,7 @@ namespace opdet {
     fInputModule = pset.get<std::string>("InputModule");
     fGenModule = pset.get<std::string>("GenModule");
     fInputLabels = pset.get<std::vector<std::string>>("InputLabels");
+    fUseStartTime = pset.get<bool>("UseStartTime", false);
 
     for (auto const& ch :
          pset.get<std::vector<unsigned int>>("ChannelMasks", std::vector<unsigned int>()))
@@ -124,22 +127,50 @@ namespace opdet {
       fCalib = new calib::PhotonCalibratorStandard(SPEArea, SPEShift, areaToPE);
     }
 
+    // Initialize the rise time calculator tool
+    using RTC = pmtana::RiseTimeCalculatorBase;
+    using PS = fhicl::ParameterSet;
+
+    PS rise_alg_pset;
+    bool computeRiseTime = pset.get_if_present< PS >("RiseTimeCalculator", rise_alg_pset);
+
     // Initialize the hit finder algorithm
     auto const hit_alg_pset = pset.get<fhicl::ParameterSet>("HitAlgoPset");
     std::string threshAlgName = hit_alg_pset.get<std::string>("Name");
-    if (threshAlgName == "Threshold")
-      fThreshAlg = new pmtana::AlgoThreshold(hit_alg_pset);
-    else if (threshAlgName == "SiPM")
-      fThreshAlg = new pmtana::AlgoSiPM(hit_alg_pset);
-    else if (threshAlgName == "SlidingWindow")
-      fThreshAlg = new pmtana::AlgoSlidingWindow(hit_alg_pset);
-    else if (threshAlgName == "FixedWindow")
-      fThreshAlg = new pmtana::AlgoFixedWindow(hit_alg_pset);
-    else if (threshAlgName == "CFD")
-      fThreshAlg = new pmtana::AlgoCFD(hit_alg_pset);
-    else
+    if (threshAlgName == "Threshold"){
+      if(computeRiseTime)
+        fThreshAlg = new pmtana::AlgoThreshold(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
+      else
+        fThreshAlg = new pmtana::AlgoThreshold(hit_alg_pset, nullptr);
+    }
+    else if (threshAlgName == "SiPM"){
+      if(computeRiseTime)
+        fThreshAlg = new pmtana::AlgoSiPM(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
+      else
+        fThreshAlg = new pmtana::AlgoSiPM(hit_alg_pset, nullptr);
+    }
+    else if (threshAlgName == "SlidingWindow"){
+      if(computeRiseTime)
+        fThreshAlg = new pmtana::AlgoSlidingWindow(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
+      else
+        fThreshAlg = new pmtana::AlgoSlidingWindow(hit_alg_pset, nullptr);
+    }
+    else if (threshAlgName == "FixedWindow"){
+      if(computeRiseTime)
+        fThreshAlg = new pmtana::AlgoFixedWindow(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
+      else
+        fThreshAlg = new pmtana::AlgoFixedWindow(hit_alg_pset, nullptr);
+    }
+    else if (threshAlgName == "CFD"){
+      if(computeRiseTime)
+        fThreshAlg = new pmtana::AlgoCFD(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
+      else
+        fThreshAlg = new pmtana::AlgoCFD(hit_alg_pset, nullptr);
+    }
+    else{
       throw art::Exception(art::errors::UnimplementedFeature)
         << "Cannot find implementation for " << threshAlgName << " algorithm.\n";
+    }
 
     auto const ped_alg_pset = pset.get<fhicl::ParameterSet>("PedAlgoPset");
     std::string pedAlgName = ped_alg_pset.get<std::string>("Name");
@@ -207,7 +238,8 @@ namespace opdet {
                    geometry,
                    fHitThreshold,
                    clock_data,
-                   calibrator);
+                   calibrator,
+                   fUseStartTime);
     }
     else {
 
@@ -243,7 +275,8 @@ namespace opdet {
                    geometry,
                    fHitThreshold,
                    clock_data,
-                   calibrator);
+                   calibrator,
+                   fUseStartTime);
     }
     // Store results into the event
     evt.put(std::move(HitPtr));

--- a/larana/OpticalDetector/OpHitFinder_module.cc
+++ b/larana/OpticalDetector/OpHitFinder_module.cc
@@ -46,6 +46,18 @@
 #include <memory>
 #include <string>
 
+namespace {
+  template <typename T>
+  pmtana::PMTPulseRecoBase* thresholdAlgorithm(fhicl::ParameterSet const& hit_alg_pset,
+                                               std::optional<fhicl::ParameterSet> const& rise_alg_pset)
+  {
+    if (rise_alg_pset)
+      return new T(hit_alg_pset, art::make_tool<pmtana::RiseTimeCalculatorBase>(*rise_alg_pset) );
+    else
+      return new T(hit_alg_pset, nullptr);
+  }
+}
+
 namespace opdet {
 
   class OpHitFinder : public art::EDProducer {
@@ -128,50 +140,26 @@ namespace opdet {
     }
 
     // Initialize the rise time calculator tool
-    using RTC = pmtana::RiseTimeCalculatorBase;
-    using PS = fhicl::ParameterSet;
-
-    PS rise_alg_pset;
-    bool computeRiseTime = pset.get_if_present< PS >("RiseTimeCalculator", rise_alg_pset);
+    auto const rise_alg_pset = pset.get_if_present<fhicl::ParameterSet>("RiseTimeCalculator");
 
     // Initialize the hit finder algorithm
     auto const hit_alg_pset = pset.get<fhicl::ParameterSet>("HitAlgoPset");
     std::string threshAlgName = hit_alg_pset.get<std::string>("Name");
-    if (threshAlgName == "Threshold"){
-      if(computeRiseTime)
-        fThreshAlg = new pmtana::AlgoThreshold(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
-      else
-        fThreshAlg = new pmtana::AlgoThreshold(hit_alg_pset, nullptr);
-    }
-    else if (threshAlgName == "SiPM"){
-      if(computeRiseTime)
-        fThreshAlg = new pmtana::AlgoSiPM(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
-      else
-        fThreshAlg = new pmtana::AlgoSiPM(hit_alg_pset, nullptr);
-    }
-    else if (threshAlgName == "SlidingWindow"){
-      if(computeRiseTime)
-        fThreshAlg = new pmtana::AlgoSlidingWindow(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
-      else
-        fThreshAlg = new pmtana::AlgoSlidingWindow(hit_alg_pset, nullptr);
-    }
-    else if (threshAlgName == "FixedWindow"){
-      if(computeRiseTime)
-        fThreshAlg = new pmtana::AlgoFixedWindow(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
-      else
-        fThreshAlg = new pmtana::AlgoFixedWindow(hit_alg_pset, nullptr);
-    }
-    else if (threshAlgName == "CFD"){
-      if(computeRiseTime)
-        fThreshAlg = new pmtana::AlgoCFD(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
-      else
-        fThreshAlg = new pmtana::AlgoCFD(hit_alg_pset, nullptr);
-    }
-    else{
+    if (threshAlgName == "Threshold")
+      fThreshAlg = thresholdAlgorithm<pmtana::AlgoThreshold>(hit_alg_pset, rise_alg_pset);
+    else if (threshAlgName == "SiPM")
+      fThreshAlg = thresholdAlgorithm<pmtana::AlgoSiPM>(hit_alg_pset, rise_alg_pset);
+    else if (threshAlgName == "SlidingWindow")
+      fThreshAlg = thresholdAlgorithm<pmtana::AlgoSlidingWindow>(hit_alg_pset, rise_alg_pset);
+    else if (threshAlgName == "FixedWindow")
+      fThreshAlg = thresholdAlgorithm<pmtana::AlgoFixedWindow>(hit_alg_pset, rise_alg_pset);
+    else if (threshAlgName == "CFD")
+      fThreshAlg = thresholdAlgorithm<pmtana::AlgoCFD>(hit_alg_pset, rise_alg_pset);
+    else
       throw art::Exception(art::errors::UnimplementedFeature)
         << "Cannot find implementation for " << threshAlgName << " algorithm.\n";
-    }
 
+    // Initialize the pedestal estimation algorithm
     auto const ped_alg_pset = pset.get<fhicl::ParameterSet>("PedAlgoPset");
     std::string pedAlgName = ped_alg_pset.get<std::string>("Name");
     if (pedAlgName == "Edges")

--- a/larana/OpticalDetector/OpHitFinder_module.cc
+++ b/larana/OpticalDetector/OpHitFinder_module.cc
@@ -73,7 +73,6 @@ namespace opdet {
 
     Float_t fHitThreshold;
     unsigned int fMaxOpChannel;
-    bool fUseStartTime;
 
     calib::IPhotonCalibrator const* fCalib = nullptr;
   };
@@ -94,7 +93,6 @@ namespace opdet {
     fInputModule = pset.get<std::string>("InputModule");
     fGenModule = pset.get<std::string>("GenModule");
     fInputLabels = pset.get<std::vector<std::string>>("InputLabels");
-    fUseStartTime = pset.get<bool>("UseStartTime", false);
 
     for (auto const& ch :
          pset.get<std::vector<unsigned int>>("ChannelMasks", std::vector<unsigned int>()))
@@ -209,8 +207,7 @@ namespace opdet {
                    geometry,
                    fHitThreshold,
                    clock_data,
-                   calibrator,
-		   fUseStartTime);
+                   calibrator);
     }
     else {
 
@@ -246,8 +243,7 @@ namespace opdet {
                    geometry,
                    fHitThreshold,
                    clock_data,
-                   calibrator,
-		   fUseStartTime);
+                   calibrator);
     }
     // Store results into the event
     evt.put(std::move(HitPtr));


### PR DESCRIPTION
This draft PR (i) modifies the OpHit finder to save the StartTime and the RiseTime new attributes added in LarSoft/lardataobj#26 and (ii) adds an art tool to calculate the RiseTime for the reconstructed pulses. Changes are summarized below.

- [OpticalDetector/OpHitFinder/OpHitAlg.h](https://github.com/LArSoft/larana/compare/develop...SBNSoftware:larana:feature/fnicolas_risetime#diff-99050a3bc342a38b16ecd65b1a9a3b4b600fd52207aad08d51ba6ee2736564c4):  it now fills the StartTime and RiseTime new members. The option to save the pulse start time (overloading the PeakTime) is removed. Note this makes this PR **backwards incompatible**. To my knowledge this option is only used by `icaruscode`. Now that the OpHit data product has been modified I think it would be more convenient to update `icaruscode` than keeping the overloading option (if that makes sense to all of you). Maybe @PetrilloAtWork or @drinkingkazu can comment on that.
- [larana/OpticalDetector/OpHitFinder/PMTPulseRecoBase.h](https://github.com/LArSoft/larana/compare/develop...SBNSoftware:larana:feature/fnicolas_risetime#diff-c6aa92ac29439b1017db420129238d39338353dbdbeb4732aecdf1f49bf27401) Add `rise_time` variable to the `pulse_param` structure.
- Add a new directory `larana/OpticalDetector/OpHitFinder/RiseTimeTools/`: The RiseTime calculation is implemented through an art tool that can be called from the different pulse finder algorithms (in this PR it's implemented only for the AlgoSlidingWindow algorithm).

Presentation at coordination meeting: https://indico.fnal.gov/event/55341/contributions/246187/attachments/157023/205182/LArSoftMeeting_larana.pdf