### PR TITLE
OpHits: Simple RiseTimeGaussFit tool added

### DIFF
--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/CMakeLists.txt
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/CMakeLists.txt
@@ -4,7 +4,6 @@ cet_make_library(LIBRARY_NAME RiseTimeCalculatorTool INTERFACE
   SOURCE 
      RiseTimeCalculatorBase.h
   LIBRARIES
-  ${ROOT_BASIC_LIB_LIST}
   ROOT::Hist
 )
 
@@ -25,7 +24,6 @@ cet_build_plugin(RiseTimeGaussFit lar::RiseTimeCalculatorTool
   LIBRARIES PRIVATE
   fhiclcpp::fhiclcpp
   ROOT::Hist
-  # ROOT::Physics
 )
 
 

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/CMakeLists.txt
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/CMakeLists.txt
@@ -1,7 +1,11 @@
 cet_enable_asserts()
 
 cet_make_library(LIBRARY_NAME RiseTimeCalculatorTool INTERFACE
-  SOURCE RiseTimeCalculatorBase.h
+  SOURCE 
+     RiseTimeCalculatorBase.h
+  LIBRARIES
+  ${ROOT_BASIC_LIB_LIST}
+  ROOT::Hist
 )
 
 cet_write_plugin_builder(lar::RiseTimeCalculatorTool art::tool Modules
@@ -15,6 +19,13 @@ include(lar::RiseTimeCalculatorTool)
 cet_build_plugin(RiseTimeThreshold lar::RiseTimeCalculatorTool
   LIBRARIES PRIVATE
   fhiclcpp::fhiclcpp
+)
+
+cet_build_plugin(RiseTimeGaussFit lar::RiseTimeCalculatorTool
+  LIBRARIES PRIVATE
+  fhiclcpp::fhiclcpp
+  ROOT::Hist
+  # ROOT::Physics
 )
 
 

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/CMakeLists.txt
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/CMakeLists.txt
@@ -23,6 +23,7 @@ cet_build_plugin(RiseTimeThreshold lar::RiseTimeCalculatorTool
 cet_build_plugin(RiseTimeGaussFit lar::RiseTimeCalculatorTool
   LIBRARIES PRIVATE
   fhiclcpp::fhiclcpp
+  messagefacility::MF_MessageLogger
   ROOT::Hist
 )
 

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
@@ -11,6 +11,7 @@
 #include "art/Utilities/ToolConfigTable.h"
 #include "art/Utilities/ToolMacros.h"
 #include "fhiclcpp/types/Atom.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
 
 #include "RiseTimeCalculatorBase.h"
 
@@ -99,7 +100,7 @@ namespace pmtana {
     }
     else {
       peak_time = first_max;
-      std::cout << "No good fit found, keeping 1st max bin instead" << std::endl;
+      mf::LogInfo("RiseTimeGaussFit") << "No good fit found, keeping 1st max bin instead";
     }
     // double peak_time= (std::abs(t_fit-first_max)<2) ?  t_fit:first_max;
 
@@ -128,7 +129,7 @@ namespace pmtana {
     }
 
     //No local maxima found.
-    std::cout << "No local max found above fixed threshold: " << threshold << std::endl;
+    mf::LogInfo("RiseTimeGaussFit") << "No local max found above fixed threshold: " << threshold;
     return 0;
   }
 }

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
@@ -2,7 +2,7 @@
  * \file RiseTimeGaussFit_tool.cc
  *
  * \brief Gaussian fit method implemented to  compute Rise time as
- * the value of the center of the first local maximum. 
+ * the value of the center of the first local maximum.
  * Fixed min threshold required set in the fhicl file
  *
  * @author Rodrigo Alvarez, Sept 2022
@@ -110,8 +110,8 @@ namespace pmtana {
                                      int low,
                                      int high,
                                      double threshold = 4.) const
-  { /** 
-    * Linear search, O(N), 1st peak should be close to the start of the vector 
+  { /**
+    * Linear search, O(N), 1st peak should be close to the start of the vector
     * for scintillation LAr Signals. Returns the position of the first local max
     **/
     double max = arr[low];

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
@@ -41,7 +41,7 @@ namespace pmtana {
                     const pmtana::PedestalMean_t& ped_pulse,
                     bool _positive) const override;
     // Method to fit the first local max of the wvf above fixed threshold
-    int findFirstMax(const std::vector<double>& arr, int low, int high, double threshold) const;
+    int findFirstMax(const std::vector<double>& arr, double threshold) const;
 
   private:
     double fMinAmp;
@@ -107,16 +107,13 @@ namespace pmtana {
   }
 
   int RiseTimeGaussFit::findFirstMax(const std::vector<double>& arr,
-                                     int low,
-                                     int high,
                                      double threshold ) const
   { /**
     * Linear search, O(N), 1st peak should be close to the start of the vector
     * for scintillation LAr Signals. Returns the position of the first local max
     **/
-    double max = arr[low];
-    int i;
-    for (i = low + 1; i < high; i++) {
+    double max = arr[0];
+    for (std::size_t i = 1, n = arr.size(); i < n; ++i) {
       if (arr[i] >= max)
         max = arr[i];
 

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
@@ -103,8 +103,7 @@ namespace pmtana {
     return peak_time;
   }
 
-  std::size_t RiseTimeGaussFit::findFirstMax(const std::vector<double>& arr,
-                                     double threshold ) const
+  std::size_t RiseTimeGaussFit::findFirstMax(const std::vector<double>& arr, double threshold) const
   { /**
     * Linear search, O(N), 1st peak should be close to the start of the vector
     * for scintillation LAr Signals. Returns the position of the first local max

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
@@ -76,7 +76,7 @@ namespace pmtana {
     }
 
     // Find first local maximum
-    size_t first_max = findFirstMax(wf_aux, 0, wf_aux.size(), fMinAmp);
+    size_t first_max = findFirstMax(wf_aux, fMinAmp);
 
     // Create & fill th1
     TH1F* h_aux = new TH1F("aux", "aux", wf_aux.size(), -0.5, wf_aux.size() - 0.5);

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
@@ -41,7 +41,7 @@ namespace pmtana {
                     const pmtana::PedestalMean_t& ped_pulse,
                     bool _positive) const override;
     // Method to fit the first local max of the wvf above fixed threshold
-    int findFirstMax(const std::vector<double>& arr, double threshold) const;
+    std::size_t findFirstMax(const std::vector<double>& arr, double threshold) const;
 
   private:
     double fMinAmp;
@@ -103,7 +103,7 @@ namespace pmtana {
     return peak_time;
   }
 
-  int RiseTimeGaussFit::findFirstMax(const std::vector<double>& arr,
+  std::size_t RiseTimeGaussFit::findFirstMax(const std::vector<double>& arr,
                                      double threshold ) const
   { /**
     * Linear search, O(N), 1st peak should be close to the start of the vector

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
@@ -102,7 +102,6 @@ namespace pmtana {
       peak_time = first_max;
       mf::LogInfo("RiseTimeGaussFit") << "No good fit found, keeping 1st max bin instead";
     }
-    // double peak_time= (std::abs(t_fit-first_max)<2) ?  t_fit:first_max;
 
     return peak_time;
   }
@@ -110,7 +109,7 @@ namespace pmtana {
   int RiseTimeGaussFit::findFirstMax(const std::vector<double>& arr,
                                      int low,
                                      int high,
-                                     double threshold = 4.) const
+                                     double threshold ) const
   { /**
     * Linear search, O(N), 1st peak should be close to the start of the vector
     * for scintillation LAr Signals. Returns the position of the first local max

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
@@ -85,10 +85,7 @@ namespace pmtana {
 
     // Function & initial values for the fit, ROOT Gaussian:  [p0]*e**(-0.5 (x-[p1])**2 / [p2]**2)
     TF1* f = new TF1("f", "gaus", double(first_max) - fNbins, double(first_max) + fNbins);
-    std::vector<double> p_init = {wf_aux[first_max], double(first_max), fInitSigma};
-    for (long unsigned int p = 0; p < wf_aux.size(); p++)
-      f->SetParameter(p, p_init[p]);
-
+    f->SetParameters(wf_aux[first_max], first_max, fInitSigma);
     // Fit
     h_aux->Fit(f, "q", "SAME", first_max - fNbins, first_max + fNbins);
     double t_fit = f->GetParameter(1);

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
@@ -1,0 +1,149 @@
+/**
+ * \file RiseTimeGaussFit_tool.cc
+ *
+ * \brief Gaussian fit method implemented to  compute Rise time as
+ * the value of the center of the first local maximum. 
+ * Fixed min threshold required set in the fhicl file
+ *
+ * @author Rodrigo Alvarez, Sept 2022
+ */
+
+#include "fhiclcpp/types/Atom.h"
+#include "art/Utilities/ToolMacros.h"
+#include "art/Utilities/ToolConfigTable.h"
+
+#include "RiseTimeCalculatorBase.h"
+
+// ROOT includes
+#include "TF1.h"
+#include "TH1F.h"
+
+namespace pmtana{
+
+  class RiseTimeGaussFit : RiseTimeCalculatorBase
+  {
+
+  public:
+
+    //Configuration parameters
+    struct Config {
+
+      fhicl::Atom<double> MinAmp {
+        fhicl::Name("MinAmp")
+      };
+      fhicl::Atom<double> InitSigma {
+        fhicl::Name("InitSigma")
+      };
+      fhicl::Atom<int> Nbins {
+        fhicl::Name("Nbins")
+      };
+      fhicl::Atom<double> Tolerance {
+        fhicl::Name("Tolerance")
+      };
+
+    };
+
+    // Default constructor
+    explicit RiseTimeGaussFit(art::ToolConfigTable<Config> const& config);
+
+    // Method to calculate the OpFlash t0
+    double RiseTime(const pmtana::Waveform_t& wf_pulse,
+                    const pmtana::PedestalMean_t& ped_pulse,
+                    bool _positive) const override;
+    // Method to fit the first local max of the wvf above fixed threshold
+    int findFirstMax(const std::vector<double>& arr, 
+                     int low, 
+                     int high,
+                     double threshold) const;
+
+  private:
+
+    double fMinAmp;
+    double fInitSigma;
+    double fTolerance;
+    int    fNbins;
+
+  };
+
+  RiseTimeGaussFit::RiseTimeGaussFit(art::ToolConfigTable<Config> const& config)
+    : fMinAmp { config().MinAmp() }
+    , fInitSigma {config().InitSigma()}
+    , fTolerance {config().Tolerance()}
+    , fNbins {config().Nbins()}
+  {
+  }
+
+  double RiseTimeGaussFit::RiseTime(const pmtana::Waveform_t& wf_pulse,
+                                     const pmtana::PedestalMean_t& ped_pulse,
+                                     bool _positive) const{
+
+    // Pedestal-subtracted pulse
+    std::vector<double> wf_aux (ped_pulse);
+    if(_positive){
+      for(size_t ix=0; ix<wf_aux.size(); ix++){
+        wf_aux[ix]=((double)wf_pulse[ix])-wf_aux[ix];
+      }
+    }
+    else{
+      for(size_t ix=0; ix<wf_aux.size(); ix++){
+        wf_aux[ix]=wf_aux[ix]-((double)wf_pulse[ix]);
+      }
+    }
+
+    // Find first local maximum
+    size_t first_max = findFirstMax(wf_aux,0,wf_aux.size(), fMinAmp);
+    
+    // Create & fill th1
+    TH1F *h_aux = new TH1F("aux", "aux", wf_aux.size(), -0.5, wf_aux.size() - 0.5);
+    for (long unsigned int j = 0; j < wf_aux.size(); j++) h_aux->SetBinContent(j+1,wf_aux[j]);
+    
+    // Function & initial values for the fit, ROOT Gaussian:  [p0]*e**(-0.5 (x-[p1])**2 / [p2]**2)
+    TF1 *f = new TF1("f","gaus",double(first_max)-fNbins,double(first_max)+fNbins);
+    std::vector<double> p_init={wf_aux[first_max],double(first_max),fInitSigma};
+    for (long unsigned int p = 0; p < wf_aux.size(); p++) f->SetParameter(p,p_init[p]);
+
+    // Fit 
+    h_aux->Fit(f,"q","SAME",first_max-fNbins,first_max+fNbins);
+    double t_fit=f->GetParameter(1);
+    double peak_time;
+    if (std::abs(t_fit-first_max)<fTolerance)
+    {//check fit is close in distance to the original max, use max peak as time otherwise
+      peak_time=t_fit;
+    }
+    else
+    {
+      peak_time=first_max;
+      std::cout<<"No good fit found, keeping 1st max bin instead"<<std::endl;
+    }
+    // double peak_time= (std::abs(t_fit-first_max)<2) ?  t_fit:first_max;
+
+
+    return peak_time;
+  }
+
+  int RiseTimeGaussFit::findFirstMax(const std::vector<double>& arr, int low, int high,double threshold=4.) 
+  const{/** 
+    * Linear search, O(N), 1st peak should be close to the start of the vector 
+    * for scintillation LAr Signals. Returns the position of the first local max
+    **/ 
+    double max = arr[low];
+    int i;
+    for (i = low + 1; i < high; i++)
+    {
+        if (arr[i] >= max) 
+            max = arr[i];
+        
+        else if(max<threshold) //didn't pass the threshold, keep searching
+            max = arr[i];
+        
+        else
+            return i-1;
+    }
+
+    //No local maxima found.
+    std::cout<<"No local max found above fixed threshold: "<< threshold<<std::endl;
+    return 0;
+  }
+}
+
+DEFINE_ART_CLASS_TOOL(pmtana::RiseTimeGaussFit)

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeGaussFit_tool.cc
@@ -8,9 +8,9 @@
  * @author Rodrigo Alvarez, Sept 2022
  */
 
-#include "fhiclcpp/types/Atom.h"
-#include "art/Utilities/ToolMacros.h"
 #include "art/Utilities/ToolConfigTable.h"
+#include "art/Utilities/ToolMacros.h"
+#include "fhiclcpp/types/Atom.h"
 
 #include "RiseTimeCalculatorBase.h"
 
@@ -18,29 +18,18 @@
 #include "TF1.h"
 #include "TH1F.h"
 
-namespace pmtana{
+namespace pmtana {
 
-  class RiseTimeGaussFit : RiseTimeCalculatorBase
-  {
+  class RiseTimeGaussFit : RiseTimeCalculatorBase {
 
   public:
-
     //Configuration parameters
     struct Config {
 
-      fhicl::Atom<double> MinAmp {
-        fhicl::Name("MinAmp")
-      };
-      fhicl::Atom<double> InitSigma {
-        fhicl::Name("InitSigma")
-      };
-      fhicl::Atom<int> Nbins {
-        fhicl::Name("Nbins")
-      };
-      fhicl::Atom<double> Tolerance {
-        fhicl::Name("Tolerance")
-      };
-
+      fhicl::Atom<double> MinAmp{fhicl::Name("MinAmp")};
+      fhicl::Atom<double> InitSigma{fhicl::Name("InitSigma")};
+      fhicl::Atom<int> Nbins{fhicl::Name("Nbins")};
+      fhicl::Atom<double> Tolerance{fhicl::Name("Tolerance")};
     };
 
     // Default constructor
@@ -51,97 +40,95 @@ namespace pmtana{
                     const pmtana::PedestalMean_t& ped_pulse,
                     bool _positive) const override;
     // Method to fit the first local max of the wvf above fixed threshold
-    int findFirstMax(const std::vector<double>& arr, 
-                     int low, 
-                     int high,
-                     double threshold) const;
+    int findFirstMax(const std::vector<double>& arr, int low, int high, double threshold) const;
 
   private:
-
     double fMinAmp;
     double fInitSigma;
     double fTolerance;
-    int    fNbins;
-
+    int fNbins;
   };
 
   RiseTimeGaussFit::RiseTimeGaussFit(art::ToolConfigTable<Config> const& config)
-    : fMinAmp { config().MinAmp() }
-    , fInitSigma {config().InitSigma()}
-    , fTolerance {config().Tolerance()}
-    , fNbins {config().Nbins()}
-  {
-  }
+    : fMinAmp{config().MinAmp()}
+    , fInitSigma{config().InitSigma()}
+    , fTolerance{config().Tolerance()}
+    , fNbins{config().Nbins()}
+  {}
 
   double RiseTimeGaussFit::RiseTime(const pmtana::Waveform_t& wf_pulse,
-                                     const pmtana::PedestalMean_t& ped_pulse,
-                                     bool _positive) const{
+                                    const pmtana::PedestalMean_t& ped_pulse,
+                                    bool _positive) const
+  {
 
     // Pedestal-subtracted pulse
-    std::vector<double> wf_aux (ped_pulse);
-    if(_positive){
-      for(size_t ix=0; ix<wf_aux.size(); ix++){
-        wf_aux[ix]=((double)wf_pulse[ix])-wf_aux[ix];
+    std::vector<double> wf_aux(ped_pulse);
+    if (_positive) {
+      for (size_t ix = 0; ix < wf_aux.size(); ix++) {
+        wf_aux[ix] = ((double)wf_pulse[ix]) - wf_aux[ix];
       }
     }
-    else{
-      for(size_t ix=0; ix<wf_aux.size(); ix++){
-        wf_aux[ix]=wf_aux[ix]-((double)wf_pulse[ix]);
+    else {
+      for (size_t ix = 0; ix < wf_aux.size(); ix++) {
+        wf_aux[ix] = wf_aux[ix] - ((double)wf_pulse[ix]);
       }
     }
 
     // Find first local maximum
-    size_t first_max = findFirstMax(wf_aux,0,wf_aux.size(), fMinAmp);
-    
-    // Create & fill th1
-    TH1F *h_aux = new TH1F("aux", "aux", wf_aux.size(), -0.5, wf_aux.size() - 0.5);
-    for (long unsigned int j = 0; j < wf_aux.size(); j++) h_aux->SetBinContent(j+1,wf_aux[j]);
-    
-    // Function & initial values for the fit, ROOT Gaussian:  [p0]*e**(-0.5 (x-[p1])**2 / [p2]**2)
-    TF1 *f = new TF1("f","gaus",double(first_max)-fNbins,double(first_max)+fNbins);
-    std::vector<double> p_init={wf_aux[first_max],double(first_max),fInitSigma};
-    for (long unsigned int p = 0; p < wf_aux.size(); p++) f->SetParameter(p,p_init[p]);
+    size_t first_max = findFirstMax(wf_aux, 0, wf_aux.size(), fMinAmp);
 
-    // Fit 
-    h_aux->Fit(f,"q","SAME",first_max-fNbins,first_max+fNbins);
-    double t_fit=f->GetParameter(1);
+    // Create & fill th1
+    TH1F* h_aux = new TH1F("aux", "aux", wf_aux.size(), -0.5, wf_aux.size() - 0.5);
+    for (long unsigned int j = 0; j < wf_aux.size(); j++)
+      h_aux->SetBinContent(j + 1, wf_aux[j]);
+
+    // Function & initial values for the fit, ROOT Gaussian:  [p0]*e**(-0.5 (x-[p1])**2 / [p2]**2)
+    TF1* f = new TF1("f", "gaus", double(first_max) - fNbins, double(first_max) + fNbins);
+    std::vector<double> p_init = {wf_aux[first_max], double(first_max), fInitSigma};
+    for (long unsigned int p = 0; p < wf_aux.size(); p++)
+      f->SetParameter(p, p_init[p]);
+
+    // Fit
+    h_aux->Fit(f, "q", "SAME", first_max - fNbins, first_max + fNbins);
+    double t_fit = f->GetParameter(1);
     double peak_time;
-    if (std::abs(t_fit-first_max)<fTolerance)
-    {//check fit is close in distance to the original max, use max peak as time otherwise
-      peak_time=t_fit;
+    if (
+      std::abs(t_fit - first_max) <
+      fTolerance) { //check fit is close in distance to the original max, use max peak as time otherwise
+      peak_time = t_fit;
     }
-    else
-    {
-      peak_time=first_max;
-      std::cout<<"No good fit found, keeping 1st max bin instead"<<std::endl;
+    else {
+      peak_time = first_max;
+      std::cout << "No good fit found, keeping 1st max bin instead" << std::endl;
     }
     // double peak_time= (std::abs(t_fit-first_max)<2) ?  t_fit:first_max;
-
 
     return peak_time;
   }
 
-  int RiseTimeGaussFit::findFirstMax(const std::vector<double>& arr, int low, int high,double threshold=4.) 
-  const{/** 
+  int RiseTimeGaussFit::findFirstMax(const std::vector<double>& arr,
+                                     int low,
+                                     int high,
+                                     double threshold = 4.) const
+  { /** 
     * Linear search, O(N), 1st peak should be close to the start of the vector 
     * for scintillation LAr Signals. Returns the position of the first local max
-    **/ 
+    **/
     double max = arr[low];
     int i;
-    for (i = low + 1; i < high; i++)
-    {
-        if (arr[i] >= max) 
-            max = arr[i];
-        
-        else if(max<threshold) //didn't pass the threshold, keep searching
-            max = arr[i];
-        
-        else
-            return i-1;
+    for (i = low + 1; i < high; i++) {
+      if (arr[i] >= max)
+        max = arr[i];
+
+      else if (max < threshold) //didn't pass the threshold, keep searching
+        max = arr[i];
+
+      else
+        return i - 1;
     }
 
     //No local maxima found.
-    std::cout<<"No local max found above fixed threshold: "<< threshold<<std::endl;
+    std::cout << "No local max found above fixed threshold: " << threshold << std::endl;
     return 0;
   }
 }

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/risetimecalculator_tool.fcl
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/risetimecalculator_tool.fcl
@@ -6,5 +6,14 @@ RiseTimeThreshold:
     PeakRatio:         0.2
 }
 
+RiseTimeGaussFit:
+{
+    tool_type: RiseTimeGaussFit
+    MinAmp:         4.0 #minimal amplitude required to the peak to be considered a local maximum (prevents picking waving points at the signal rise)
+    InitSigma:      8.0 # of the gauss fit
+    Nbins:          3   # to use in the gauss fit, same Nbins left & right
+    Tolerance:      2   # |BinFit-BinMax|<tolerance, prevents bad fitting results 
+}
+
 
 END_PROLOG


### PR DESCRIPTION
Instead of computing rise time of Optical Hits with respect to the relative max amplitude, this tool looks for the first maximum of an optical signal and fits the peak to a gaussian.
The tool has a minimum Amplitud threshold for it to be considered the maximum, and a tolerance number of bins, to prevent bad fittings.

A diagram of the algorithm is atached below:
![image](https://user-images.githubusercontent.com/70945401/207306532-1906fa90-ac03-40ca-9834-6c56281b2ebb.png)


This approach has been tested with good results in the reconstruction of filtered X-Arapuca signals in SBND simulations
(see [docdb 29133](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=29133), [28150](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=28150) for more details.
