### PR TITLE
Bug fixes to optical hit pedestal reconstruction "rolling mean" algorithm

### DIFF
--- a/larana/OpticalDetector/OpHitFinder/PedAlgoRollingMean.cxx
+++ b/larana/OpticalDetector/OpHitFinder/PedAlgoRollingMean.cxx
@@ -168,7 +168,7 @@ namespace pmtana {
 
             auto presample_mean =
               edge_aware_mean(wf, last_good_index - _n_presamples, last_good_index);
-            auto postsample_mean = edge_aware_mean(wf, i, _n_presamples);
+            auto postsample_mean = edge_aware_mean(wf, i, i + _n_presamples);
 
             auto diff_pre = fabs(presample_mean - mode_mean);
             auto diff_post = fabs(postsample_mean - mode_mean);
@@ -282,7 +282,7 @@ namespace pmtana {
       }
       else {
 
-        auto presample_mean = edge_aware_mean(wf, first_index - _n_presamples, second_index);
+        auto presample_mean = edge_aware_mean(wf, second_index - _n_presamples, second_index);
 
         for (int j = second_index + 1; j < int(wf.size()); ++j) {
           //mean_v.at(j)  = floor( mean_v.at(first_index) ) + _random_shift + (double) ( rand() % _range) / _divisions;

--- a/larana/OpticalDetector/OpHitFinder/PedAlgoRollingMean.cxx
+++ b/larana/OpticalDetector/OpHitFinder/PedAlgoRollingMean.cxx
@@ -131,9 +131,7 @@ namespace pmtana {
 
     //std::cout<<mode_mean<<" +/- "<<mode_sigma<<std::endl;
 
-    _diff_threshold *= mode_sigma;
-
-    double diff_cutoff = _diff_threshold < _diff_adc_count ? _diff_adc_count : _diff_threshold;
+    double const diff_cutoff = std::max(_diff_threshold * mode_sigma, _diff_adc_count);
 
     int last_good_index = -1;
 


### PR DESCRIPTION
Two details of the rolling mean pedestal algorithm are almost surely bugs.
A fix is presented here.

The first sees an increase of a threshold as more and more hits are processed in the job.
Eventually the threshold will become unpassable and the code will never use interpolation to cover the signal (or high-RMS regions) of the waveforms, but always use the pedestal before or after the region. Which is probably a more sensitive choice at least in ICARUS.

The second bug is repeated in two places. In the first, it makes the post-region baseline (mean) be `0` (because extracted out of `0` samples), and the algorithm is most likely going to choose the mean on the pre-region instead. Which is probably a more sensitive choice at least in ICARUS. In the second, the pre-region mean is extracted from a slightly extended interval, affecting the pedestal of the region at the beginning of the waveform if there is signal in it. The effect of this one is likely completely negligible.

The impact seems very, very minor on three events from ICARUS data I have tested.
Developed and tested with `icaruscode` `v09_65_03`.