### PR TITLE
Optical hit reconstruction algorithms selected via art tools

### DIFF
--- a/larana/OpticalDetector/AlgoCFDMaker_tool.cc
+++ b/larana/OpticalDetector/AlgoCFDMaker_tool.cc
@@ -1,0 +1,18 @@
+/**
+ * @file   larana/OpticalDetector/AlgoCFDMaker_tool.cc
+ * @brief  _art_ tool to create a `pmtana::AlgoCFD` algorithm.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ */
+
+// LArSoft libraries
+#include "larana/OpticalDetector/HitAlgoMakerToolBase.h"
+#include "larana/OpticalDetector/OpHitFinder/AlgoCFD.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::AlgoCFD>)
+

--- a/larana/OpticalDetector/AlgoCFDMaker_tool.cc
+++ b/larana/OpticalDetector/AlgoCFDMaker_tool.cc
@@ -12,7 +12,5 @@
 // framework libraries
 #include "art/Utilities/ToolMacros.h"
 
-
 // -----------------------------------------------------------------------------
 DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::AlgoCFD>)
-

--- a/larana/OpticalDetector/AlgoFixedWindowMaker_tool.cc
+++ b/larana/OpticalDetector/AlgoFixedWindowMaker_tool.cc
@@ -12,7 +12,5 @@
 // framework libraries
 #include "art/Utilities/ToolMacros.h"
 
-
 // -----------------------------------------------------------------------------
 DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::AlgoFixedWindow>)
-

--- a/larana/OpticalDetector/AlgoFixedWindowMaker_tool.cc
+++ b/larana/OpticalDetector/AlgoFixedWindowMaker_tool.cc
@@ -1,0 +1,18 @@
+/**
+ * @file   larana/OpticalDetector/AlgoFixedWindowMaker_tool.cc
+ * @brief  _art_ tool to create a `pmtana::AlgoFixedWindow` algorithm.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ */
+
+// LArSoft libraries
+#include "larana/OpticalDetector/HitAlgoMakerToolBase.h"
+#include "larana/OpticalDetector/OpHitFinder/AlgoFixedWindow.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::AlgoFixedWindow>)
+

--- a/larana/OpticalDetector/AlgoSiPMMaker_tool.cc
+++ b/larana/OpticalDetector/AlgoSiPMMaker_tool.cc
@@ -1,0 +1,18 @@
+/**
+ * @file   larana/OpticalDetector/AlgoSiPMMaker_tool.cc
+ * @brief  _art_ tool to create a `pmtana::AlgoSiPM` algorithm.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ */
+
+// LArSoft libraries
+#include "larana/OpticalDetector/HitAlgoMakerToolBase.h"
+#include "larana/OpticalDetector/OpHitFinder/AlgoSiPM.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::AlgoSiPM>)
+

--- a/larana/OpticalDetector/AlgoSiPMMaker_tool.cc
+++ b/larana/OpticalDetector/AlgoSiPMMaker_tool.cc
@@ -12,7 +12,5 @@
 // framework libraries
 #include "art/Utilities/ToolMacros.h"
 
-
 // -----------------------------------------------------------------------------
 DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::AlgoSiPM>)
-

--- a/larana/OpticalDetector/AlgoSlidingWindowMaker_tool.cc
+++ b/larana/OpticalDetector/AlgoSlidingWindowMaker_tool.cc
@@ -12,7 +12,5 @@
 // framework libraries
 #include "art/Utilities/ToolMacros.h"
 
-
 // -----------------------------------------------------------------------------
 DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::AlgoSlidingWindow>)
-

--- a/larana/OpticalDetector/AlgoSlidingWindowMaker_tool.cc
+++ b/larana/OpticalDetector/AlgoSlidingWindowMaker_tool.cc
@@ -1,0 +1,18 @@
+/**
+ * @file   larana/OpticalDetector/AlgoSlidingWindowMaker_tool.cc
+ * @brief  _art_ tool to create a `pmtana::AlgoSlidingWindow` algorithm.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ */
+
+// LArSoft libraries
+#include "larana/OpticalDetector/HitAlgoMakerToolBase.h"
+#include "larana/OpticalDetector/OpHitFinder/AlgoSlidingWindow.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::AlgoSlidingWindow>)
+

--- a/larana/OpticalDetector/AlgoThresholdMaker_tool.cc
+++ b/larana/OpticalDetector/AlgoThresholdMaker_tool.cc
@@ -1,0 +1,18 @@
+/**
+ * @file   larana/OpticalDetector/AlgoThresholdMaker_tool.cc
+ * @brief  _art_ tool to create a `pmtana::AlgoThreshold` algorithm.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ */
+
+// LArSoft libraries
+#include "larana/OpticalDetector/HitAlgoMakerToolBase.h"
+#include "larana/OpticalDetector/OpHitFinder/AlgoThreshold.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::AlgoThreshold>)
+

--- a/larana/OpticalDetector/AlgoThresholdMaker_tool.cc
+++ b/larana/OpticalDetector/AlgoThresholdMaker_tool.cc
@@ -12,7 +12,5 @@
 // framework libraries
 #include "art/Utilities/ToolMacros.h"
 
-
 // -----------------------------------------------------------------------------
 DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::AlgoThreshold>)
-

--- a/larana/OpticalDetector/CMakeLists.txt
+++ b/larana/OpticalDetector/CMakeLists.txt
@@ -315,6 +315,56 @@ cet_build_plugin(PhotonInf art::EDAnalyzer
   ROOT::Tree
 )
 
+# --- BEGIN -- hit finding algorithm maker tools -------------------------------
+cet_make_library(LIBRARY_NAME HitAlgoMakerTool INTERFACE
+  SOURCE
+    IHitAlgoMakerTool.h
+    HitAlgoMakerToolBase.h
+  )
+
+cet_write_plugin_builder(lar::HitAlgoMakerTool art::tool Modules
+  INSTALL_BUILDER
+  LIBRARIES
+    larana::OpticalDetector_OpHitFinder
+    fhiclcpp::fhiclcpp
+)
+
+include(lar::HitAlgoMakerTool)
+
+foreach(AlgoName CFD FixedWindow SiPM SlidingWindow Threshold )
+  cet_build_plugin(Algo${AlgoName}Maker lar::HitAlgoMakerTool
+    LIBRARIES PRIVATE
+      larana::OpticalDetector_OpHitFinder
+      fhiclcpp::fhiclcpp
+  )
+endforeach(AlgoName)
+# --- END ---- hit finding algorithm maker tools -------------------------------
+
+# --- BEGIN -- pedestal estimator algorithm maker tools ------------------------
+cet_make_library(LIBRARY_NAME PedAlgoMakerTool INTERFACE
+  SOURCE
+    IPedAlgoMakerTool.h
+    PedAlgoMakerToolBase.h
+  )
+
+cet_write_plugin_builder(lar::PedAlgoMakerTool art::tool Modules
+  INSTALL_BUILDER
+  LIBRARIES
+    larana::OpticalDetector_OpHitFinder
+    fhiclcpp::fhiclcpp
+)
+
+include(lar::PedAlgoMakerTool)
+
+foreach(AlgoName Edges RollingMean UB )
+  cet_build_plugin(PedAlgo${AlgoName}Maker lar::PedAlgoMakerTool
+    LIBRARIES PRIVATE
+      larana::OpticalDetector_OpHitFinder
+      fhiclcpp::fhiclcpp
+  )
+endforeach(AlgoName)
+# --- END ---- pedestal estimator algorithm maker tools ------------------------
+
 install_headers()
 install_fhicl()
 install_source()

--- a/larana/OpticalDetector/HitAlgoMakerToolBase.h
+++ b/larana/OpticalDetector/HitAlgoMakerToolBase.h
@@ -3,7 +3,7 @@
  * @brief  Base class wrapping hit finding algorithms into _art_ tools.
  * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
  * @date   February 12, 2023
- * 
+ *
  * This library is header-only.
  */
 
@@ -18,28 +18,30 @@
 // framework libraries
 #include "art/Utilities/ToolConfigTable.h"
 #include "art/Utilities/make_tool.h"
-#include "fhiclcpp/types/OptionalDelegatedParameter.h"
-#include "fhiclcpp/types/DelegatedParameter.h"
 #include "fhiclcpp/ParameterSet.h"
+#include "fhiclcpp/types/DelegatedParameter.h"
+#include "fhiclcpp/types/OptionalDelegatedParameter.h"
 
-
-namespace opdet { template <class HitAlgoClass> class HitAlgoMakerToolBase; }
+namespace opdet {
+  template <class HitAlgoClass>
+  class HitAlgoMakerToolBase;
+}
 
 /**
  * @brief Base _art_ tool class wrapping a hit algorithm.
  * @tparam HitAlgoClass the hit finder algorithm class being created
- * 
+ *
  * Algorithms of the hit finding mini-framework in `larana` follow a factory
  * pattern which is not the one native in _art_.
- * 
+ *
  * This base class provides the backbone to a _art_ tool wrapping one of the hit
  * finder algorithms. The only function of these tools is to create and
  * configure a hit finder algorithm object: the tools do not offer any hit
  * finding functionality by themselves.
- * 
+ *
  * Note that these tools all implement a single _art_ tool interface, which
  * is defined as `opdet::IHitAlgoMakerTool`.
- * 
+ *
  * The current _art_ plugin system will be content with a simple declaration
  * like:
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
@@ -49,83 +51,72 @@ namespace opdet { template <class HitAlgoClass> class HitAlgoMakerToolBase; }
  * This definition needs to live in a source file with an appropriate name
  * (e.g. `AlgoSlidingWindowMaker_tool.cc`), as the source name will be used to
  * identify which library to load at run time.
- * 
+ *
  * Hit finder class (`HitAlgoClass`) requirements
  * -----------------------------------------------
- * 
+ *
  * The constructor of the hit finder class, `HitAlgoClass`, must support two
  * parameters:
- *     
+ *
  *     HitAlgoClass::HitAlgoClass(
- *       fhicl::ParameterSet const& config, 
+ *       fhicl::ParameterSet const& config,
  *       std::unique_ptr<pmtana::RiseTimeCalculatorBase>&& riseCalcAlgo
  *       );
- *     
- * 
+ *
+ *
  */
 template <class HitAlgoClass>
-class opdet::HitAlgoMakerToolBase: public opdet::IHitAlgoMakerTool {
-  
-    public:
-  
+class opdet::HitAlgoMakerToolBase : public opdet::IHitAlgoMakerTool {
+
+public:
   struct Config {
-    
+
     fhicl::DelegatedParameter HitAlgoPset{
-      fhicl::Name{ "HitAlgoPset" },
-      fhicl::Comment{ "configuration of the hit finder algorithm" }
-      };
-    
+      fhicl::Name{"HitAlgoPset"},
+      fhicl::Comment{"configuration of the hit finder algorithm"}};
+
     fhicl::OptionalDelegatedParameter RiseTimeCalculator{
-      fhicl::Name{ "RiseTimeCalculator" },
-      fhicl::Comment{ "configuration of the rise time calculator algorithm" }
-      };
-    
+      fhicl::Name{"RiseTimeCalculator"},
+      fhicl::Comment{"configuration of the rise time calculator algorithm"}};
+
   }; // struct Config
-  
+
   using Parameters = art::ToolConfigTable<Config>;
-  
-  
+
   /// Constructor: copies and stores the configuration for the algorithm.
   HitAlgoMakerToolBase(Parameters const& params);
-  
+
   /// Creates and returns the algorithm from the configuration on construction.
   virtual std::unique_ptr<pmtana::PMTPulseRecoBase> makeAlgo() override;
-  
-  
-    protected:
-  
-  Config fConfig; ///< Tool configuration cache.
-  
-}; // opdet::HitAlgoMakerToolBase
 
+protected:
+  Config fConfig; ///< Tool configuration cache.
+
+}; // opdet::HitAlgoMakerToolBase
 
 // -----------------------------------------------------------------------------
 // ---  template implementation
 // -----------------------------------------------------------------------------
 template <class HitAlgoClass>
-opdet::HitAlgoMakerToolBase<HitAlgoClass>::HitAlgoMakerToolBase
-  (Parameters const& params)
-  : fConfig{ params() }
-  {}
-
+opdet::HitAlgoMakerToolBase<HitAlgoClass>::HitAlgoMakerToolBase(Parameters const& params)
+  : fConfig{params()}
+{}
 
 // -----------------------------------------------------------------------------
 template <class HitAlgoClass>
-std::unique_ptr<pmtana::PMTPulseRecoBase>
-opdet::HitAlgoMakerToolBase<HitAlgoClass>::makeAlgo() {
-  
-  std::unique_ptr<pmtana::RiseTimeCalculatorBase> riseCalcAlgo
-    = fConfig.RiseTimeCalculator.hasValue()
-    ? art::make_tool<pmtana::RiseTimeCalculatorBase>
-      (fConfig.RiseTimeCalculator.template get_if_present<fhicl::ParameterSet>().value())
-    : nullptr
-    ;
-  
-  return std::make_unique<HitAlgoClass>
-    (fConfig.HitAlgoPset.template get<fhicl::ParameterSet>(), std::move(riseCalcAlgo));
-  
-} // opdet::HitAlgoMakerToolBase::makeAlgo()
+std::unique_ptr<pmtana::PMTPulseRecoBase> opdet::HitAlgoMakerToolBase<HitAlgoClass>::makeAlgo()
+{
 
+  std::unique_ptr<pmtana::RiseTimeCalculatorBase> riseCalcAlgo =
+    fConfig.RiseTimeCalculator.hasValue() ?
+      art::make_tool<pmtana::RiseTimeCalculatorBase>(
+        fConfig.RiseTimeCalculator.template get_if_present<fhicl::ParameterSet>().value()) :
+      nullptr;
+
+  return std::make_unique<HitAlgoClass>(fConfig.HitAlgoPset.template get<fhicl::ParameterSet>(),
+                                        std::move(riseCalcAlgo));
+
+} // opdet::HitAlgoMakerToolBase::makeAlgo()
 
 // -----------------------------------------------------------------------------
 

--- a/larana/OpticalDetector/HitAlgoMakerToolBase.h
+++ b/larana/OpticalDetector/HitAlgoMakerToolBase.h
@@ -1,0 +1,132 @@
+/**
+ * @file   larana/OpticalDetector/HitAlgoMakerToolBase.h
+ * @brief  Base class wrapping hit finding algorithms into _art_ tools.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ * 
+ * This library is header-only.
+ */
+
+#ifndef LARANA_OPTICALDETECTOR_HITALGOMAKERTOOLBASE_H
+#define LARANA_OPTICALDETECTOR_HITALGOMAKERTOOLBASE_H
+
+// LArSoft libraries
+#include "larana/OpticalDetector/IHitAlgoMakerTool.h"
+#include "larana/OpticalDetector/OpHitFinder/PMTPulseRecoBase.h"
+#include "larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeCalculatorBase.h"
+
+// framework libraries
+#include "art/Utilities/ToolConfigTable.h"
+#include "art/Utilities/make_tool.h"
+#include "fhiclcpp/types/OptionalDelegatedParameter.h"
+#include "fhiclcpp/types/DelegatedParameter.h"
+#include "fhiclcpp/ParameterSet.h"
+
+
+namespace opdet { template <class HitAlgoClass> class HitAlgoMakerToolBase; }
+
+/**
+ * @brief Base _art_ tool class wrapping a hit algorithm.
+ * @tparam HitAlgoClass the hit finder algorithm class being created
+ * 
+ * Algorithms of the hit finding mini-framework in `larana` follow a factory
+ * pattern which is not the one native in _art_.
+ * 
+ * This base class provides the backbone to a _art_ tool wrapping one of the hit
+ * finder algorithms. The only function of these tools is to create and
+ * configure a hit finder algorithm object: the tools do not offer any hit
+ * finding functionality by themselves.
+ * 
+ * Note that these tools all implement a single _art_ tool interface, which
+ * is defined as `opdet::IHitAlgoMakerTool`.
+ * 
+ * The current _art_ plugin system will be content with a simple declaration
+ * like:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::AlgoSlidingWindow>)
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * for defining the tool that creates a `pmtana::AlgoSlidingWindow` algorithm.
+ * This definition needs to live in a source file with an appropriate name
+ * (e.g. `AlgoSlidingWindowMaker_tool.cc`), as the source name will be used to
+ * identify which library to load at run time.
+ * 
+ * Hit finder class (`HitAlgoClass`) requirements
+ * -----------------------------------------------
+ * 
+ * The constructor of the hit finder class, `HitAlgoClass`, must support two
+ * parameters:
+ *     
+ *     HitAlgoClass::HitAlgoClass(
+ *       fhicl::ParameterSet const& config, 
+ *       std::unique_ptr<pmtana::RiseTimeCalculatorBase>&& riseCalcAlgo
+ *       );
+ *     
+ * 
+ */
+template <class HitAlgoClass>
+class opdet::HitAlgoMakerToolBase: public opdet::IHitAlgoMakerTool {
+  
+    public:
+  
+  struct Config {
+    
+    fhicl::DelegatedParameter HitAlgoPset{
+      fhicl::Name{ "HitAlgoPset" },
+      fhicl::Comment{ "configuration of the hit finder algorithm" }
+      };
+    
+    fhicl::OptionalDelegatedParameter RiseTimeCalculator{
+      fhicl::Name{ "RiseTimeCalculator" },
+      fhicl::Comment{ "configuration of the rise time calculator algorithm" }
+      };
+    
+  }; // struct Config
+  
+  using Parameters = art::ToolConfigTable<Config>;
+  
+  
+  /// Constructor: copies and stores the configuration for the algorithm.
+  HitAlgoMakerToolBase(Parameters const& params);
+  
+  /// Creates and returns the algorithm from the configuration on construction.
+  virtual std::unique_ptr<pmtana::PMTPulseRecoBase> makeAlgo() override;
+  
+  
+    protected:
+  
+  Config fConfig; ///< Tool configuration cache.
+  
+}; // opdet::HitAlgoMakerToolBase
+
+
+// -----------------------------------------------------------------------------
+// ---  template implementation
+// -----------------------------------------------------------------------------
+template <class HitAlgoClass>
+opdet::HitAlgoMakerToolBase<HitAlgoClass>::HitAlgoMakerToolBase
+  (Parameters const& params)
+  : fConfig{ params() }
+  {}
+
+
+// -----------------------------------------------------------------------------
+template <class HitAlgoClass>
+std::unique_ptr<pmtana::PMTPulseRecoBase>
+opdet::HitAlgoMakerToolBase<HitAlgoClass>::makeAlgo() {
+  
+  std::unique_ptr<pmtana::RiseTimeCalculatorBase> riseCalcAlgo
+    = fConfig.RiseTimeCalculator.hasValue()
+    ? art::make_tool<pmtana::RiseTimeCalculatorBase>
+      (fConfig.RiseTimeCalculator.template get_if_present<fhicl::ParameterSet>().value())
+    : nullptr
+    ;
+  
+  return std::make_unique<HitAlgoClass>
+    (fConfig.HitAlgoPset.template get<fhicl::ParameterSet>(), std::move(riseCalcAlgo));
+  
+} // opdet::HitAlgoMakerToolBase::makeAlgo()
+
+
+// -----------------------------------------------------------------------------
+
+#endif // LARANA_OPTICALDETECTOR_HITALGOMAKERTOOLBASE_H

--- a/larana/OpticalDetector/IHitAlgoMakerTool.h
+++ b/larana/OpticalDetector/IHitAlgoMakerTool.h
@@ -1,0 +1,62 @@
+/**
+ * @file   larana/OpticalDetector/IHitAlgoMakerTool.h
+ * @brief  Tool interface for creating a hit finder algorithm.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ * 
+ * This library is header-only.
+ */
+
+#ifndef LARANA_OPTICALDETECTOR_IHITALGOMAKERTOOL_H
+#define LARANA_OPTICALDETECTOR_IHITALGOMAKERTOOL_H
+
+// LArSoft libraries
+#include "larana/OpticalDetector/OpHitFinder/PMTPulseRecoBase.h"
+
+// C/C++ standard libraries
+#include <memory>
+
+// -----------------------------------------------------------------------------
+namespace opdet { class IHitAlgoMakerTool; }
+/**
+ * @brief Tool interface for creating a hit finder algorithm.
+ * 
+ * The hit finder algorithms in `larana` implement a common abstraction and
+ * interface (`pmtana::PMTPulseRecoBase`).
+ * In principle, wrappers may be written as _art_ tools that implement that same
+ * interface and wrap the actual algorithms. In this case, users will actually
+ * use the tool classes as hit finder algorithms.
+ * In alternative, _art_ tools may be written to _create_ the current hit finder
+ * algorithms. In this case, users will use the tool only at setup stage to
+ * create the hit finder algorithms, and then the tools will have no further
+ * role.
+ * 
+ * This class provides the interface for a tool following this second design:
+ * a tool following this interface will be able to create hit finder algorithm
+ * objects by executing `makeAlgo()`, and that will be the only function of the
+ * tool.
+ */
+struct opdet::IHitAlgoMakerTool {
+  
+  virtual ~IHitAlgoMakerTool() = default;
+  
+  /**
+   * @brief Creates and returns a new instance of hit finder algorithm.
+   * @return the newly created algorithm instance
+   * 
+   * The returned object is completely independent of this tool: after calling
+   * this function, the tool can in principle be discarded.
+   * 
+   * Note that all the information necessary to the creation of the algorithm
+   * must have already been passed to the tool (and stored) in the FHiCL
+   * configuration on construction.
+   */
+  virtual std::unique_ptr<pmtana::PMTPulseRecoBase> makeAlgo() = 0;
+  
+  
+}; // opdet::IHitAlgoMakerTool
+
+
+// -----------------------------------------------------------------------------
+
+#endif // LARANA_OPTICALDETECTOR_IHITALGOMAKERTOOL_H

--- a/larana/OpticalDetector/IHitAlgoMakerTool.h
+++ b/larana/OpticalDetector/IHitAlgoMakerTool.h
@@ -18,7 +18,7 @@
 
 // -----------------------------------------------------------------------------
 namespace opdet {
-  class IHitAlgoMakerTool;
+  struct IHitAlgoMakerTool;
 }
 /**
  * @brief Tool interface for creating a hit finder algorithm.

--- a/larana/OpticalDetector/IHitAlgoMakerTool.h
+++ b/larana/OpticalDetector/IHitAlgoMakerTool.h
@@ -3,7 +3,7 @@
  * @brief  Tool interface for creating a hit finder algorithm.
  * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
  * @date   February 12, 2023
- * 
+ *
  * This library is header-only.
  */
 
@@ -17,10 +17,12 @@
 #include <memory>
 
 // -----------------------------------------------------------------------------
-namespace opdet { class IHitAlgoMakerTool; }
+namespace opdet {
+  class IHitAlgoMakerTool;
+}
 /**
  * @brief Tool interface for creating a hit finder algorithm.
- * 
+ *
  * The hit finder algorithms in `larana` implement a common abstraction and
  * interface (`pmtana::PMTPulseRecoBase`).
  * In principle, wrappers may be written as _art_ tools that implement that same
@@ -30,32 +32,30 @@ namespace opdet { class IHitAlgoMakerTool; }
  * algorithms. In this case, users will use the tool only at setup stage to
  * create the hit finder algorithms, and then the tools will have no further
  * role.
- * 
+ *
  * This class provides the interface for a tool following this second design:
  * a tool following this interface will be able to create hit finder algorithm
  * objects by executing `makeAlgo()`, and that will be the only function of the
  * tool.
  */
 struct opdet::IHitAlgoMakerTool {
-  
+
   virtual ~IHitAlgoMakerTool() = default;
-  
+
   /**
    * @brief Creates and returns a new instance of hit finder algorithm.
    * @return the newly created algorithm instance
-   * 
+   *
    * The returned object is completely independent of this tool: after calling
    * this function, the tool can in principle be discarded.
-   * 
+   *
    * Note that all the information necessary to the creation of the algorithm
    * must have already been passed to the tool (and stored) in the FHiCL
    * configuration on construction.
    */
   virtual std::unique_ptr<pmtana::PMTPulseRecoBase> makeAlgo() = 0;
-  
-  
-}; // opdet::IHitAlgoMakerTool
 
+}; // opdet::IHitAlgoMakerTool
 
 // -----------------------------------------------------------------------------
 

--- a/larana/OpticalDetector/IPedAlgoMakerTool.h
+++ b/larana/OpticalDetector/IPedAlgoMakerTool.h
@@ -1,0 +1,61 @@
+/**
+ * @file   larana/OpticalDetector/IPedAlgoMakerTool.h
+ * @brief  Tool interface for creating a pedestal estimator algorithm.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ * 
+ * This library is header-only.
+ */
+
+#ifndef LARANA_OPTICALDETECTOR_IPEDALGOMAKERTOOL_H
+#define LARANA_OPTICALDETECTOR_IPEDALGOMAKERTOOL_H
+
+// LArSoft libraries
+#include "larana/OpticalDetector/OpHitFinder/PMTPedestalBase.h"
+
+// C/C++ standard libraries
+#include <memory>
+
+// -----------------------------------------------------------------------------
+namespace opdet { class IPedAlgoMakerTool; }
+/**
+ * @brief Tool interface for creating a pedestal estimator algorithm.
+ * 
+ * The pedestal estimator algorithms in `larana` implement a common abstraction
+ * and interface (`pmtana::PMTPedestalBase`).
+ * In principle, wrappers may be written as _art_ tools that implement that same
+ * interface and wrap the actual algorithms. In this case, users will actually
+ * use the tool classes as pedestal estimator algorithms.
+ * In alternative, _art_ tools may be written to _create_ the current pedestal
+ * estimator algorithms. In this case, users will use the tool only at setup
+ * stage to create the algorithms, and then the tools will have no further role.
+ * 
+ * This class provides the interface for a tool following this second design:
+ * a tool following this interface will be able to create pedestal estimator
+ * algorithm objects by executing `makeAlgo()`, and that will be the only
+ * function of the tool.
+ */
+struct opdet::IPedAlgoMakerTool {
+  
+  virtual ~IPedAlgoMakerTool() = default;
+  
+  /**
+   * @brief Creates and returns a new instance of pedestal estimator algorithm.
+   * @return the newly created algorithm instance
+   * 
+   * The returned object is completely independent of this tool: after calling
+   * this function, the tool can in principle be discarded.
+   * 
+   * Note that all the information necessary to the creation of the algorithm
+   * must have already been passed to the tool (and stored) in the FHiCL
+   * configuration on construction.
+   */
+  virtual std::unique_ptr<pmtana::PMTPedestalBase> makeAlgo() = 0;
+  
+  
+}; // opdet::IPedAlgoMakerTool
+
+
+// -----------------------------------------------------------------------------
+
+#endif // LARANA_OPTICALDETECTOR_IPEDALGOMAKERTOOL_H

--- a/larana/OpticalDetector/IPedAlgoMakerTool.h
+++ b/larana/OpticalDetector/IPedAlgoMakerTool.h
@@ -18,7 +18,7 @@
 
 // -----------------------------------------------------------------------------
 namespace opdet {
-  class IPedAlgoMakerTool;
+  struct IPedAlgoMakerTool;
 }
 /**
  * @brief Tool interface for creating a pedestal estimator algorithm.

--- a/larana/OpticalDetector/IPedAlgoMakerTool.h
+++ b/larana/OpticalDetector/IPedAlgoMakerTool.h
@@ -3,7 +3,7 @@
  * @brief  Tool interface for creating a pedestal estimator algorithm.
  * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
  * @date   February 12, 2023
- * 
+ *
  * This library is header-only.
  */
 
@@ -17,10 +17,12 @@
 #include <memory>
 
 // -----------------------------------------------------------------------------
-namespace opdet { class IPedAlgoMakerTool; }
+namespace opdet {
+  class IPedAlgoMakerTool;
+}
 /**
  * @brief Tool interface for creating a pedestal estimator algorithm.
- * 
+ *
  * The pedestal estimator algorithms in `larana` implement a common abstraction
  * and interface (`pmtana::PMTPedestalBase`).
  * In principle, wrappers may be written as _art_ tools that implement that same
@@ -29,32 +31,30 @@ namespace opdet { class IPedAlgoMakerTool; }
  * In alternative, _art_ tools may be written to _create_ the current pedestal
  * estimator algorithms. In this case, users will use the tool only at setup
  * stage to create the algorithms, and then the tools will have no further role.
- * 
+ *
  * This class provides the interface for a tool following this second design:
  * a tool following this interface will be able to create pedestal estimator
  * algorithm objects by executing `makeAlgo()`, and that will be the only
  * function of the tool.
  */
 struct opdet::IPedAlgoMakerTool {
-  
+
   virtual ~IPedAlgoMakerTool() = default;
-  
+
   /**
    * @brief Creates and returns a new instance of pedestal estimator algorithm.
    * @return the newly created algorithm instance
-   * 
+   *
    * The returned object is completely independent of this tool: after calling
    * this function, the tool can in principle be discarded.
-   * 
+   *
    * Note that all the information necessary to the creation of the algorithm
    * must have already been passed to the tool (and stored) in the FHiCL
    * configuration on construction.
    */
   virtual std::unique_ptr<pmtana::PMTPedestalBase> makeAlgo() = 0;
-  
-  
-}; // opdet::IPedAlgoMakerTool
 
+}; // opdet::IPedAlgoMakerTool
 
 // -----------------------------------------------------------------------------
 

--- a/larana/OpticalDetector/PedAlgoEdgesMaker_tool.cc
+++ b/larana/OpticalDetector/PedAlgoEdgesMaker_tool.cc
@@ -1,0 +1,18 @@
+/**
+ * @file   larana/OpticalDetector/PedAlgoEdgesMaker_tool.cc
+ * @brief  _art_ tool to create a `pmtana::PedAlgoEdges` algorithm.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ */
+
+// LArSoft libraries
+#include "larana/OpticalDetector/PedAlgoMakerToolBase.h"
+#include "larana/OpticalDetector/OpHitFinder/PedAlgoEdges.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(opdet::PedAlgoMakerToolBase<pmtana::PedAlgoEdges>)
+

--- a/larana/OpticalDetector/PedAlgoEdgesMaker_tool.cc
+++ b/larana/OpticalDetector/PedAlgoEdgesMaker_tool.cc
@@ -6,13 +6,11 @@
  */
 
 // LArSoft libraries
-#include "larana/OpticalDetector/PedAlgoMakerToolBase.h"
 #include "larana/OpticalDetector/OpHitFinder/PedAlgoEdges.h"
+#include "larana/OpticalDetector/PedAlgoMakerToolBase.h"
 
 // framework libraries
 #include "art/Utilities/ToolMacros.h"
 
-
 // -----------------------------------------------------------------------------
 DEFINE_ART_CLASS_TOOL(opdet::PedAlgoMakerToolBase<pmtana::PedAlgoEdges>)
-

--- a/larana/OpticalDetector/PedAlgoMakerToolBase.h
+++ b/larana/OpticalDetector/PedAlgoMakerToolBase.h
@@ -3,7 +3,7 @@
  * @brief  Base class wrapping hit finding algorithms into _art_ tools.
  * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
  * @date   February 12, 2023
- * 
+ *
  * This library is header-only.
  */
 
@@ -18,28 +18,30 @@
 // framework libraries
 #include "art/Utilities/ToolConfigTable.h"
 #include "art/Utilities/make_tool.h"
-#include "fhiclcpp/types/OptionalDelegatedParameter.h"
-#include "fhiclcpp/types/DelegatedParameter.h"
 #include "fhiclcpp/ParameterSet.h"
+#include "fhiclcpp/types/DelegatedParameter.h"
+#include "fhiclcpp/types/OptionalDelegatedParameter.h"
 
-
-namespace opdet { template <class PedAlgoClass> class PedAlgoMakerToolBase; }
+namespace opdet {
+  template <class PedAlgoClass>
+  class PedAlgoMakerToolBase;
+}
 
 /**
  * @brief Base _art_ tool class wrapping a pedestal estimator algorithm.
  * @tparam PedAlgoClass the pedestal estimator algorithm class being created
- * 
+ *
  * Algorithms of the pedestal estimation mini-framework in `larana` follow a
  * factory pattern which is not the one native in _art_.
- * 
+ *
  * This base class provides the backbone to a _art_ tool wrapping one of the
  * pedestal estimator algorithms. The only function of these tools is to create
  * and configure a pedestal estimator algorithm object: the tools do not offer
  * any pedestal estimation functionality by themselves.
- * 
+ *
  * Note that these tools all implement a single _art_ tool interface, which
  * is defined as `opdet::IPedAlgoMakerTool`.
- * 
+ *
  * The current _art_ plugin system will be content with a simple declaration
  * like:
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
@@ -49,69 +51,59 @@ namespace opdet { template <class PedAlgoClass> class PedAlgoMakerToolBase; }
  * This definition needs to live in a source file with an appropriate name
  * (e.g. `PedAlgoRollingMeanMaker_tool.cc`), as the source name will be used to
  * identify which library to load at run time.
- * 
- * 
+ *
+ *
  * Pedestal estimator class (`PedAlgoClass`) requirements
  * -----------------------------------------------
- * 
+ *
  * The constructor of the pedestal estimator class, `PedAlgoClass`, must support
  * one parameter:
- *     
+ *
  *     PedAlgoClass::PedAlgoClass(fhicl::ParameterSet const& config);
- *     
- * 
+ *
+ *
  */
 template <class PedAlgoClass>
-class opdet::PedAlgoMakerToolBase: public opdet::IPedAlgoMakerTool {
-  
-    public:
-  
+class opdet::PedAlgoMakerToolBase : public opdet::IPedAlgoMakerTool {
+
+public:
   struct Config {
-    
+
     fhicl::DelegatedParameter PedAlgoPset{
-      fhicl::Name{ "PedAlgoPset" },
-      fhicl::Comment{ "configuration of the pedestal estimator  algorithm" }
-      };
-    
+      fhicl::Name{"PedAlgoPset"},
+      fhicl::Comment{"configuration of the pedestal estimator  algorithm"}};
+
   }; // struct Config
-  
+
   using Parameters = art::ToolConfigTable<Config>;
-  
-  
+
   /// Constructor: copies and stores the configuration for the algorithm.
   PedAlgoMakerToolBase(Parameters const& params);
-  
+
   /// Creates and returns the algorithm from the configuration on construction.
   virtual std::unique_ptr<pmtana::PMTPedestalBase> makeAlgo() override;
-  
-  
-    protected:
-  
-  Config fConfig; ///< Tool configuration cache.
-  
-}; // opdet::PedAlgoMakerToolBase
 
+protected:
+  Config fConfig; ///< Tool configuration cache.
+
+}; // opdet::PedAlgoMakerToolBase
 
 // -----------------------------------------------------------------------------
 // ---  template implementation
 // -----------------------------------------------------------------------------
 template <class PedAlgoClass>
-opdet::PedAlgoMakerToolBase<PedAlgoClass>::PedAlgoMakerToolBase
-  (Parameters const& params)
-  : fConfig{ params() }
-  {}
-
+opdet::PedAlgoMakerToolBase<PedAlgoClass>::PedAlgoMakerToolBase(Parameters const& params)
+  : fConfig{params()}
+{}
 
 // -----------------------------------------------------------------------------
 template <class PedAlgoClass>
-std::unique_ptr<pmtana::PMTPedestalBase>
-opdet::PedAlgoMakerToolBase<PedAlgoClass>::makeAlgo() {
-  
-  return std::make_unique<PedAlgoClass>
-    (fConfig.PedAlgoPset.template get<fhicl::ParameterSet>());
-  
-} // opdet::PedAlgoMakerToolBase::makeAlgo()
+std::unique_ptr<pmtana::PMTPedestalBase> opdet::PedAlgoMakerToolBase<PedAlgoClass>::makeAlgo()
+{
 
+  return std::make_unique<PedAlgoClass>(fConfig.PedAlgoPset.template get<fhicl::ParameterSet>());
+
+} // opdet::PedAlgoMakerToolBase::makeAlgo()
 
 // -----------------------------------------------------------------------------
 

--- a/larana/OpticalDetector/PedAlgoMakerToolBase.h
+++ b/larana/OpticalDetector/PedAlgoMakerToolBase.h
@@ -1,0 +1,118 @@
+/**
+ * @file   larana/OpticalDetector/PedAlgoMakerToolBase.h
+ * @brief  Base class wrapping hit finding algorithms into _art_ tools.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ * 
+ * This library is header-only.
+ */
+
+#ifndef LARANA_OPTICALDETECTOR_PEDALGOMAKERTOOLBASE_H
+#define LARANA_OPTICALDETECTOR_PEDALGOMAKERTOOLBASE_H
+
+// LArSoft libraries
+#include "larana/OpticalDetector/IPedAlgoMakerTool.h"
+#include "larana/OpticalDetector/OpHitFinder/PMTPedestalBase.h"
+#include "larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeCalculatorBase.h"
+
+// framework libraries
+#include "art/Utilities/ToolConfigTable.h"
+#include "art/Utilities/make_tool.h"
+#include "fhiclcpp/types/OptionalDelegatedParameter.h"
+#include "fhiclcpp/types/DelegatedParameter.h"
+#include "fhiclcpp/ParameterSet.h"
+
+
+namespace opdet { template <class PedAlgoClass> class PedAlgoMakerToolBase; }
+
+/**
+ * @brief Base _art_ tool class wrapping a pedestal estimator algorithm.
+ * @tparam PedAlgoClass the pedestal estimator algorithm class being created
+ * 
+ * Algorithms of the pedestal estimation mini-framework in `larana` follow a
+ * factory pattern which is not the one native in _art_.
+ * 
+ * This base class provides the backbone to a _art_ tool wrapping one of the
+ * pedestal estimator algorithms. The only function of these tools is to create
+ * and configure a pedestal estimator algorithm object: the tools do not offer
+ * any pedestal estimation functionality by themselves.
+ * 
+ * Note that these tools all implement a single _art_ tool interface, which
+ * is defined as `opdet::IPedAlgoMakerTool`.
+ * 
+ * The current _art_ plugin system will be content with a simple declaration
+ * like:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * DEFINE_ART_CLASS_TOOL(opdet::HitAlgoMakerToolBase<pmtana::PedAlgoRollingMean>)
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * for defining the tool that creates a `pmtana::PedAlgoRollingMean` algorithm.
+ * This definition needs to live in a source file with an appropriate name
+ * (e.g. `PedAlgoRollingMeanMaker_tool.cc`), as the source name will be used to
+ * identify which library to load at run time.
+ * 
+ * 
+ * Pedestal estimator class (`PedAlgoClass`) requirements
+ * -----------------------------------------------
+ * 
+ * The constructor of the pedestal estimator class, `PedAlgoClass`, must support
+ * one parameter:
+ *     
+ *     PedAlgoClass::PedAlgoClass(fhicl::ParameterSet const& config);
+ *     
+ * 
+ */
+template <class PedAlgoClass>
+class opdet::PedAlgoMakerToolBase: public opdet::IPedAlgoMakerTool {
+  
+    public:
+  
+  struct Config {
+    
+    fhicl::DelegatedParameter PedAlgoPset{
+      fhicl::Name{ "PedAlgoPset" },
+      fhicl::Comment{ "configuration of the pedestal estimator  algorithm" }
+      };
+    
+  }; // struct Config
+  
+  using Parameters = art::ToolConfigTable<Config>;
+  
+  
+  /// Constructor: copies and stores the configuration for the algorithm.
+  PedAlgoMakerToolBase(Parameters const& params);
+  
+  /// Creates and returns the algorithm from the configuration on construction.
+  virtual std::unique_ptr<pmtana::PMTPedestalBase> makeAlgo() override;
+  
+  
+    protected:
+  
+  Config fConfig; ///< Tool configuration cache.
+  
+}; // opdet::PedAlgoMakerToolBase
+
+
+// -----------------------------------------------------------------------------
+// ---  template implementation
+// -----------------------------------------------------------------------------
+template <class PedAlgoClass>
+opdet::PedAlgoMakerToolBase<PedAlgoClass>::PedAlgoMakerToolBase
+  (Parameters const& params)
+  : fConfig{ params() }
+  {}
+
+
+// -----------------------------------------------------------------------------
+template <class PedAlgoClass>
+std::unique_ptr<pmtana::PMTPedestalBase>
+opdet::PedAlgoMakerToolBase<PedAlgoClass>::makeAlgo() {
+  
+  return std::make_unique<PedAlgoClass>
+    (fConfig.PedAlgoPset.template get<fhicl::ParameterSet>());
+  
+} // opdet::PedAlgoMakerToolBase::makeAlgo()
+
+
+// -----------------------------------------------------------------------------
+
+#endif // LARANA_OPTICALDETECTOR_PEDALGOMAKERTOOLBASE_H

--- a/larana/OpticalDetector/PedAlgoRollingMeanMaker_tool.cc
+++ b/larana/OpticalDetector/PedAlgoRollingMeanMaker_tool.cc
@@ -1,0 +1,18 @@
+/**
+ * @file   larana/OpticalDetector/PedAlgoRollingMeanMaker_tool.cc
+ * @brief  _art_ tool to create a `pmtana::PedAlgoRollingMean` algorithm.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ */
+
+// LArSoft libraries
+#include "larana/OpticalDetector/PedAlgoMakerToolBase.h"
+#include "larana/OpticalDetector/OpHitFinder/PedAlgoRollingMean.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(opdet::PedAlgoMakerToolBase<pmtana::PedAlgoRollingMean>)
+

--- a/larana/OpticalDetector/PedAlgoRollingMeanMaker_tool.cc
+++ b/larana/OpticalDetector/PedAlgoRollingMeanMaker_tool.cc
@@ -6,13 +6,11 @@
  */
 
 // LArSoft libraries
-#include "larana/OpticalDetector/PedAlgoMakerToolBase.h"
 #include "larana/OpticalDetector/OpHitFinder/PedAlgoRollingMean.h"
+#include "larana/OpticalDetector/PedAlgoMakerToolBase.h"
 
 // framework libraries
 #include "art/Utilities/ToolMacros.h"
 
-
 // -----------------------------------------------------------------------------
 DEFINE_ART_CLASS_TOOL(opdet::PedAlgoMakerToolBase<pmtana::PedAlgoRollingMean>)
-

--- a/larana/OpticalDetector/PedAlgoUBMaker_tool.cc
+++ b/larana/OpticalDetector/PedAlgoUBMaker_tool.cc
@@ -1,0 +1,18 @@
+/**
+ * @file   larana/OpticalDetector/PedAlgoUBMaker_tool.cc
+ * @brief  _art_ tool to create a `pmtana::PedAlgoUB` algorithm.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   February 12, 2023
+ */
+
+// LArSoft libraries
+#include "larana/OpticalDetector/PedAlgoMakerToolBase.h"
+#include "larana/OpticalDetector/OpHitFinder/PedAlgoUB.h"
+
+// framework libraries
+#include "art/Utilities/ToolMacros.h"
+
+
+// -----------------------------------------------------------------------------
+DEFINE_ART_CLASS_TOOL(opdet::PedAlgoMakerToolBase<pmtana::PedAlgoUB>)
+

--- a/larana/OpticalDetector/PedAlgoUBMaker_tool.cc
+++ b/larana/OpticalDetector/PedAlgoUBMaker_tool.cc
@@ -6,13 +6,11 @@
  */
 
 // LArSoft libraries
-#include "larana/OpticalDetector/PedAlgoMakerToolBase.h"
 #include "larana/OpticalDetector/OpHitFinder/PedAlgoUB.h"
+#include "larana/OpticalDetector/PedAlgoMakerToolBase.h"
 
 // framework libraries
 #include "art/Utilities/ToolMacros.h"
 
-
 // -----------------------------------------------------------------------------
 DEFINE_ART_CLASS_TOOL(opdet::PedAlgoMakerToolBase<pmtana::PedAlgoUB>)
-


### PR DESCRIPTION
The current optical hit reconstruction is performed by algorithms managed by a "mini-framework".
The management of the algorithms in LArSoft is semi-dynamic (or semi-static?), in that the algorithms are chosen at run time, but only among a hard-coded selection of algorithms.

This pull request changes the loading mechanism in `ophit::OpHitFinder` module to leverage on _art_ tool feature.
The algorithms are not changed (neither their functionality, nor the interface).

This allows the experiments to test additional algorithms or modifications of the existing ones without forking `OpHitFinder` module.

## Usage

As also mentioned below, this is not a breaking change, as **support for legacy configuration syntax is explicitly provided**.
To configure one hit finder algorithm, now and before two configuration tables are needed: `HitAlgoPset` and the optional `RiseTimeCalculator`. The only new feature is that `HitAlgoPset` may (and, I argue, _should_) specify explicitly also the `tool_type` setting to find the correct tool (`AlgoXxxxMaker` for the algorithm with `Name: Xxxx`).

Similarly for the pedestal estimation algorithm, the configuration table name is still `PedAlgoPset`, which optionally now also accepts `tool_type` (`PedAlgoXxxxMaker` will use the algorithm with `Name: Xxxx`).

## Testing

I have reconstructed three ICARUS data events with the reconstruction in `v09_65_03` before and after the changes (that amounts to more than 50k `recob::OpHits`). I have used the `OpHit` dumper (which does not exist... I should open another pull request for that...) and verified that the output is identical up to the precision of the dumping on screen.

## Implementation details

There are two sets of algorithms: pedestal estimation and hit (pulse) reconstruction. The latter is complicated by the presence of an optional algorithm for the computation of the rise time.

This pull request introduces short-lived _art_ tools that _create_ the algorithms (which are instead long-lived).
For each of the two types of algorithms, a algorithm-maker interface is defined (just a `makeAlgo()`), and a template tool class is provided to create one of the several available algorithms. Here "template" is also the literal C++ feature.
This makes writing new tools very simple (it's effectively one C++ line of code).

The module (`OpHitFinder`) contains some code to allow for the standard tool specification in _art_ (`tool_type`), and also to make it out of the existing configurations (legacy support), inferring the value of `tool_type` from `Name` with heuristics that work for all the existing algorithms — I don't promise that will hold for the future ones, so the new interface should be used.

Note that while the template tool uses the validated FHiCL configuration, neither the module nor the algorithms use it, so no validation is effectively enforced.

## Notes for the reviewers

* although I don't know the factory system of _art_ well enough to predict if the absence of a simple class for the tool has any effect (currently the tool class is a template instantiation;
* I have tried to guess how to explain CMake about these tools; while it seems to have understood, I still have little idea of what I did and why it should, could or did work; please check that with particular care.


