### PR TITLE
Removing some extra computation on Chi2PIDA

### DIFF
--- a/larana/ParticleIdentification/Chi2PIDAlg.cxx
+++ b/larana/ParticleIdentification/Chi2PIDAlg.cxx
@@ -83,17 +83,19 @@ anab::ParticleID pid::Chi2PIDAlg::DoParticleID(
     std::vector<float> deadwireresrc = calo->DeadWireResRC();
 
     int used_trkres = 0;
+    int nbins_dedx_range = dedx_range_pro->GetNbinsX();
     for (unsigned i = 0; i < trkdedx.size(); ++i) { //hits
       //ignore the first and the last point
       if (i == 0 || i == trkdedx.size() - 1) continue;
       if (trkres[i] < 30) {
-        PIDA += trkdedx[i] * pow(trkres[i], 0.42);
-        vpida.push_back(trkdedx[i] * pow(trkres[i], 0.42));
+        double PIDAi = trkdedx[i] * pow(trkres[i], 0.42);
+        PIDA += PIDAi;
+        vpida.push_back(PIDAi);
         used_trkres++;
       }
       if (trkdedx[i] > 1000) continue; //protect against large pulse height
       int bin = dedx_range_pro->FindBin(trkres[i]);
-      if (bin >= 1 && bin <= dedx_range_pro->GetNbinsX()) {
+      if (bin >= 1 && bin <= nbins_dedx_range) {
         double bincpro = dedx_range_pro->GetBinContent(bin);
         if (bincpro < 1e-6) { //for 0 bin content, using neighboring bins
           bincpro =
@@ -134,10 +136,13 @@ anab::ParticleID pid::Chi2PIDAlg::DoParticleID(
         //double errke = 0.05*trkdedx[i];   //5% KE resolution
         double errdedx = 0.04231 + 0.0001783 * trkdedx[i] * trkdedx[i]; //resolution on dE/dx
         errdedx *= trkdedx[i];
-        chi2pro += pow((trkdedx[i] - bincpro) / std::sqrt(pow(binepro, 2) + pow(errdedx, 2)), 2);
-        chi2ka += pow((trkdedx[i] - bincka) / std::sqrt(pow(bineka, 2) + pow(errdedx, 2)), 2);
-        chi2pi += pow((trkdedx[i] - bincpi) / std::sqrt(pow(binepi, 2) + pow(errdedx, 2)), 2);
-        chi2mu += pow((trkdedx[i] - bincmu) / std::sqrt(pow(binemu, 2) + pow(errdedx, 2)), 2);
+
+        double errdedx_square = errdedx*errdedx
+        chi2pro += pow((trkdedx[i] - bincpro), 2) / (binepro*binepro + errdedx_square);
+        chi2ka +=  pow((trkdedx[i] - bincka) , 2) / (bineka*bineka + errdedx_square);
+        chi2pi +=  pow((trkdedx[i] - bincpi) , 2) / (binepi*binepi + errdedx_square);
+        chi2mu +=  pow((trkdedx[i] - bincmu) , 2) / (binemu*binemu + errdedx_square);
+
         //std::cout<<i<<" "<<trkdedx[i]<<" "<<trkres[i]<<" "<<bincpro<<std::endl;
         ++npt;
       }

--- a/larana/ParticleIdentification/Chi2PIDAlg.cxx
+++ b/larana/ParticleIdentification/Chi2PIDAlg.cxx
@@ -137,11 +137,11 @@ anab::ParticleID pid::Chi2PIDAlg::DoParticleID(
         double errdedx = 0.04231 + 0.0001783 * trkdedx[i] * trkdedx[i]; //resolution on dE/dx
         errdedx *= trkdedx[i];
 
-        double errdedx_square = errdedx*errdedx
-        chi2pro += pow((trkdedx[i] - bincpro), 2) / (binepro*binepro + errdedx_square);
-        chi2ka +=  pow((trkdedx[i] - bincka) , 2) / (bineka*bineka + errdedx_square);
-        chi2pi +=  pow((trkdedx[i] - bincpi) , 2) / (binepi*binepi + errdedx_square);
-        chi2mu +=  pow((trkdedx[i] - bincmu) , 2) / (binemu*binemu + errdedx_square);
+        double errdedx_square = errdedx * errdedx;
+        chi2pro += pow((trkdedx[i] - bincpro), 2) / (binepro * binepro + errdedx_square);
+        chi2ka += pow((trkdedx[i] - bincka), 2) / (bineka * bineka + errdedx_square);
+        chi2pi += pow((trkdedx[i] - bincpi), 2) / (binepi * binepi + errdedx_square);
+        chi2mu += pow((trkdedx[i] - bincmu), 2) / (binemu * binemu + errdedx_square);
 
         //std::cout<<i<<" "<<trkdedx[i]<<" "<<trkres[i]<<" "<<bincpro<<std::endl;
         ++npt;


### PR DESCRIPTION
I don't really know if this is interesting, but going through the code I saw that `pow` and `sqrt` were being called a few times without need. 
