### PR TITLE
Updates pida

### DIFF
--- a/larana/ParticleIdentification/Chi2PIDAlg.cxx
+++ b/larana/ParticleIdentification/Chi2PIDAlg.cxx
@@ -30,7 +30,7 @@ pid::Chi2PIDAlg::Chi2PIDAlg(fhicl::ParameterSet const& pset)
   fTemplateFile = pset.get<std::string>("TemplateFile");
   fUseMedian = pset.get<bool>("UseMedian");
   fLimitPIDA = pset.get<bool>("LimitPIDA");
-  fMaximumPIDA = pset.get<float>("MaximumPIDA");
+  fMaximumPIDA = pset.get<double>("MaximumPIDA");
   //fCalorimetryModuleLabel = pset.get< std::string >("CalorimetryModuleLabel");
 
   cet::search_path sp("FW_SEARCH_PATH");

--- a/larana/ParticleIdentification/Chi2PIDAlg.cxx
+++ b/larana/ParticleIdentification/Chi2PIDAlg.cxx
@@ -92,7 +92,7 @@ anab::ParticleID pid::Chi2PIDAlg::DoParticleID(
       //ignore the first and the last point
       if (i == 0 || i == trkdedx.size() - 1) continue;
       if (trkdedx[i] > 1000) continue; //protect against large pulse height
-      if (trkres[i] < 30) { // pida is evaluated over the last 30 cm
+      if (trkres[i] < 30) {            // pida is evaluated over the last 30 cm
         double PIDAi = trkdedx[i] * pow(trkres[i], 0.42);
         if (fLimitPIDA && PIDAi > fMaximumPIDA) continue;
         PIDA += PIDAi;

--- a/larana/ParticleIdentification/Chi2PIDAlg.cxx
+++ b/larana/ParticleIdentification/Chi2PIDAlg.cxx
@@ -29,8 +29,7 @@ pid::Chi2PIDAlg::Chi2PIDAlg(fhicl::ParameterSet const& pset)
 {
   fTemplateFile = pset.get<std::string>("TemplateFile");
   fUseMedian = pset.get<bool>("UseMedian");
-  fLimitPIDA = pset.get<bool>("LimitPIDA");
-  fMaximumPIDA = pset.get<double>("MaximumPIDA");
+  fMaximumPIDA = pset.get_if_present<double>("MaximumPIDA");
   //fCalorimetryModuleLabel = pset.get< std::string >("CalorimetryModuleLabel");
 
   cet::search_path sp("FW_SEARCH_PATH");
@@ -94,7 +93,7 @@ anab::ParticleID pid::Chi2PIDAlg::DoParticleID(
       if (trkdedx[i] > 1000) continue; //protect against large pulse height
       if (trkres[i] < 30) {            // pida is evaluated over the last 30 cm
         double PIDAi = trkdedx[i] * pow(trkres[i], 0.42);
-        if (fLimitPIDA && PIDAi > fMaximumPIDA) continue;
+        if (fMaximumPIDA && PIDAi > *fMaximumPIDA) continue;
         PIDA += PIDAi;
         vpida.push_back(PIDAi);
         used_trkres++;

--- a/larana/ParticleIdentification/Chi2PIDAlg.h
+++ b/larana/ParticleIdentification/Chi2PIDAlg.h
@@ -10,6 +10,7 @@
 
 #include <bitset>
 #include <string>
+#include <optional>
 
 namespace fhicl {
   class ParameterSet;
@@ -42,8 +43,7 @@ namespace pid {
   private:
     std::string fTemplateFile;
     bool fUseMedian;
-    bool fLimitPIDA;
-    double fMaximumPIDA;
+    std::optional<double> fMaximumPIDA;
     //std::string fCalorimetryModuleLabel;
     std::string fROOTfile;
 

--- a/larana/ParticleIdentification/Chi2PIDAlg.h
+++ b/larana/ParticleIdentification/Chi2PIDAlg.h
@@ -9,8 +9,8 @@
 #define CHI2PIDALG_H
 
 #include <bitset>
-#include <string>
 #include <optional>
+#include <string>
 
 namespace fhicl {
   class ParameterSet;

--- a/larana/ParticleIdentification/Chi2PIDAlg.h
+++ b/larana/ParticleIdentification/Chi2PIDAlg.h
@@ -42,6 +42,8 @@ namespace pid {
   private:
     std::string fTemplateFile;
     bool fUseMedian;
+    bool fLimitPIDA;
+    double fMaximumPIDA;
     //std::string fCalorimetryModuleLabel;
     std::string fROOTfile;
 

--- a/larana/ParticleIdentification/pidalgorithms.fcl
+++ b/larana/ParticleIdentification/pidalgorithms.fcl
@@ -4,6 +4,8 @@ standard_chi2pidalg:
 {
     TemplateFile:           "dEdxrestemplates.root"
     UseMedian:              true
+    LimitPIDA:              false
+    MaximumPIDA:            30
 }
 
 standard_pidaalg:

--- a/larana/ParticleIdentification/pidalgorithms.fcl
+++ b/larana/ParticleIdentification/pidalgorithms.fcl
@@ -4,8 +4,7 @@ standard_chi2pidalg:
 {
     TemplateFile:           "dEdxrestemplates.root"
     UseMedian:              true
-    LimitPIDA:              false
-    MaximumPIDA:            30
+    # MaximumPIDA:            30 # Optional argument: limits PIDA values that are considered for median or mean
 }
 
 standard_pidaalg:


### PR DESCRIPTION
1 - Modifed position of the check:
```
      if (trkdedx[i] > 1000) continue; //protect against large pulse height
```
This safety check was being done for PID chi2 but not PIDA. 

2 - Addition of limitation on PIDA accepted values and ndf. This modification should not impact standard analysis as it is set to false. In my analysis, changing it to true has improved proton identification. 