### PR TITLE
MVAAlg Bug Fix

### DIFF
--- a/larana/ParticleIdentification/MVAAlg.cxx
+++ b/larana/ParticleIdentification/MVAAlg.cxx
@@ -303,7 +303,8 @@ void mvapid::MVAAlg::PrepareEvent(const art::Event& evt,
 
   for (unsigned int iTrack = 0; iTrack < fTracks.size(); ++iTrack) {
     const art::Ptr<recob::Track> track = fTracks.at(iTrack);
-
+    fTracksToHits[track] = std::vector<art::Ptr<recob::Hit>>();
+    fTracksToSpacePoints[track] = std::vector<art::Ptr<recob::SpacePoint>>();
     const std::vector<art::Ptr<recob::Hit>> trackHits = findTracksToHits.at(iTrack);
 
     for (unsigned int iHit = 0; iHit < trackHits.size(); ++iHit) {
@@ -317,6 +318,8 @@ void mvapid::MVAAlg::PrepareEvent(const art::Event& evt,
 
   for (unsigned int iShower = 0; iShower < fShowers.size(); ++iShower) {
     const art::Ptr<recob::Shower> shower = fShowers.at(iShower);
+    fShowersToHits[shower] = std::vector<art::Ptr<recob::Hit>>();
+    fShowersToSpacePoints[shower] = std::vector<art::Ptr<recob::SpacePoint>>();
     const std::vector<art::Ptr<recob::Hit>> showerHits = findShowersToHits.at(iShower);
 
     for (unsigned int iHit = 0; iHit < showerHits.size(); ++iHit) {

--- a/larana/ParticleIdentification/MVAAlg.cxx
+++ b/larana/ParticleIdentification/MVAAlg.cxx
@@ -303,8 +303,8 @@ void mvapid::MVAAlg::PrepareEvent(const art::Event& evt,
 
   for (unsigned int iTrack = 0; iTrack < fTracks.size(); ++iTrack) {
     const art::Ptr<recob::Track> track = fTracks.at(iTrack);
-    fTracksToHits[track] = std::vector<art::Ptr<recob::Hit>>();
-    fTracksToSpacePoints[track] = std::vector<art::Ptr<recob::SpacePoint>>();
+    fTracksToHits[track];
+    fTracksToSpacePoints[track];
     const std::vector<art::Ptr<recob::Hit>> trackHits = findTracksToHits.at(iTrack);
 
     for (unsigned int iHit = 0; iHit < trackHits.size(); ++iHit) {
@@ -318,8 +318,8 @@ void mvapid::MVAAlg::PrepareEvent(const art::Event& evt,
 
   for (unsigned int iShower = 0; iShower < fShowers.size(); ++iShower) {
     const art::Ptr<recob::Shower> shower = fShowers.at(iShower);
-    fShowersToHits[shower] = std::vector<art::Ptr<recob::Hit>>();
-    fShowersToSpacePoints[shower] = std::vector<art::Ptr<recob::SpacePoint>>();
+    fShowersToHits[shower];
+    fShowersToSpacePoints[shower];
     const std::vector<art::Ptr<recob::Hit>> showerHits = findShowersToHits.at(iShower);
 
     for (unsigned int iHit = 0; iHit < showerHits.size(); ++iHit) {


### PR DESCRIPTION
This PR fixes a bug in larana/ParticleIdentification/MVAAlg.cxx. The code was trying to access an element in fTrackToHits/fTracksToSpacePoints/fShowerToHits/fShowerToSpacePoints that did not exist.