### PR TITLE
Remove use of art's `art::Event::getView`

### DIFF
--- a/larana/OpticalDetector/OpHitFinder_module.cc
+++ b/larana/OpticalDetector/OpHitFinder_module.cc
@@ -248,14 +248,6 @@ namespace opdet {
     // These is the storage pointer we will put in the event
     std::unique_ptr<std::vector<recob::OpHit>> HitPtr(new std::vector<recob::OpHit>);
 
-    std::vector<const sim::BeamGateInfo*> beamGateArray;
-    try {
-      evt.getView(fGenModule, beamGateArray);
-    }
-    catch (art::Exception const& err) {
-      if (err.categoryCode() != art::errors::ProductNotFound) throw;
-    }
-
     auto const& wireReadoutGeom = art::ServiceHandle<geo::WireReadout const>()->Get();
     auto const clock_data =
       art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);

--- a/larana/OpticalDetector/OpticalRawDigitReformatter_module.cc
+++ b/larana/OpticalDetector/OpticalRawDigitReformatter_module.cc
@@ -84,14 +84,6 @@ namespace opdet {
       RawOpDetVecs.push_back(std::move(tmp));
     }
 
-    std::vector<const sim::BeamGateInfo*> beamGateArray;
-    try {
-      evt.getView(fGenModule, beamGateArray);
-    }
-    catch (art::Exception const& err) {
-      if (err.categoryCode() != art::errors::ProductNotFound) throw;
-    }
-
     // Read in the OpticalRawDigit collection from the event.
     art::Handle<std::vector<optdata::OpticalRawDigit>> ordHandle;
     evt.getByLabel(fInputModule, ordHandle);

--- a/larana/OpticalDetector/PMTAna_module.cc
+++ b/larana/OpticalDetector/PMTAna_module.cc
@@ -97,42 +97,11 @@ namespace pmtana {
   void PMTAna::analyze(const art::Event& evt)
   //#######################################################################################################
   {
+    auto const& pmts = evt.getHandle<std::vector<raw::OpDetWaveform>>(_fifo_mod_name);
+    if (!pmts) { return; }
 
-    //data_ptr->set_event(evt.id().event(), evt.run(), evt.subRun());
-
-    //    std::vector<const optdata::FIFOChannel*> pmtArray;
-    std::vector<const raw::OpDetWaveform*> pmtArray;
-    try {
-
-      evt.getView(_fifo_mod_name, pmtArray);
-    }
-    catch (art::Exception const& e) {
-
-      if (e.categoryCode() != art::errors::ProductNotFound) throw;
-    }
-
-    for (size_t i = 0; i < pmtArray.size(); ++i) {
-
-      //      const optdata::FIFOChannel* fifo_ptr(pmtArray.at(i));
-      const raw::OpDetWaveform* fifo_ptr(pmtArray.at(i));
-
-      _preco_man.Reconstruct(*fifo_ptr);
-
-      //
-      // here I add code to store reco-ed pulse w/ channel number
-      // OR I may make a singleton storage manager...
-
-      /*
-      data_ptr->add_pmtfifo(fifo_ptr->ChannelNumber(),
-			    fifo_ptr->Category(),
-			    fifo_ptr->Frame(),
-			    fifo_ptr->TimeSlice(),
-			    *fifo_ptr);
-			    */
-
-      //
-      //
-      //
+    for (raw::OpDetWaveform const& waveform : *pmts) {
+      _preco_man.Reconstruct(waveform);
     }
   }
 

--- a/larana/OpticalDetector/SimPhotonCounter_module.cc
+++ b/larana/OpticalDetector/SimPhotonCounter_module.cc
@@ -333,12 +333,11 @@ namespace opdet {
 
       // loop over all sim::SimChannels in the event and make sure there are no
       // sim::IDEs with trackID values that are not in the sim::ParticleList
-      std::vector<const sim::SimChannel*> sccol;
       for (auto const& mod : fInputModule) {
-        evt.getView(mod, sccol);
+        auto const& sccol = evt.getProduct<std::vector<sim::SimChannel>>(mod);
         //loop over the sim channels collection
-        for (size_t sc = 0; sc < sccol.size(); ++sc) {
-          const auto& tdcidemap = sccol[sc]->TDCIDEMap();
+        for (sim::SimChannel const& sc : sccol) {
+          const auto& tdcidemap = sc.TDCIDEMap();
           //loop over all of the tdc IDE map objects
           for (auto mapitr = tdcidemap.begin(); mapitr != tdcidemap.end(); mapitr++) {
             const std::vector<sim::IDE> idevec = (*mapitr).second;


### PR DESCRIPTION
All instances of `art::Event::getView(...)` are unnecessary as only data products of the type `std::vector<T>`s are retrieved when `getView(...)` is called. Because the Phlex framework will not support the equivalent of art views, this PR removes their unnecessary use.