### PR TITLE
Adding PhysdEdx and LikelihoodPIDAlg for a new PID based on likelihood of dE/dx

### DIFF
--- a/larana/ParticleIdentification/CMakeLists.txt
+++ b/larana/ParticleIdentification/CMakeLists.txt
@@ -44,6 +44,17 @@ cet_build_plugin(Chi2ParticleID art::EDProducer
   fhiclcpp::fhiclcpp
 )
 
+cet_build_plugin(LikelihoodParticleID art::EDProducer
+  LIBRARIES PRIVATE
+  larana::ParticleIdentification
+  lardata::AssociationUtil
+  lardataobj::AnalysisBase
+  lardataobj::RecoBase
+  art::Framework_Principal
+  canvas::canvas
+  fhiclcpp::fhiclcpp
+)
+
 cet_build_plugin(MVAPID art::EDProducer
   LIBRARIES PRIVATE
   larana::ParticleIdentification

--- a/larana/ParticleIdentification/CMakeLists.txt
+++ b/larana/ParticleIdentification/CMakeLists.txt
@@ -1,10 +1,13 @@
 cet_make_library(SOURCE
+  PhysdEdx.cxx
   Chi2PIDAlg.cxx
 	MVAAlg.cxx
-  PIDAAlg.cxx
+	PIDAAlg.cxx
+  LikelihoodPIDAlg.cxx
   LIBRARIES
   PUBLIC
   larreco::Calorimetry
+  larreco::RecoAlg
   lardataobj::AnalysisBase
   larcoreobj::SimpleTypesAndConstants
   canvas::canvas
@@ -12,6 +15,7 @@ cet_make_library(SOURCE
   ROOT::Hist
   ROOT::Physics
   ROOT::TMVA
+  ROOT::MathMore
   PRIVATE
   lardata::AssociationUtil
   lardata::DetectorClocksService

--- a/larana/ParticleIdentification/CMakeLists.txt
+++ b/larana/ParticleIdentification/CMakeLists.txt
@@ -2,7 +2,7 @@ cet_make_library(SOURCE
   PhysdEdx.cxx
   Chi2PIDAlg.cxx
 	MVAAlg.cxx
-	PIDAAlg.cxx
+  PIDAAlg.cxx
   LikelihoodPIDAlg.cxx
   LIBRARIES
   PUBLIC

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
@@ -25,7 +25,7 @@
 //------------------------------------------------------------------------------
 pid::LikelihoodPIDAlg::LikelihoodPIDAlg(fhicl::ParameterSet const& pset)
 {
-  fSkipNhits = pset.get<int>("SkipNhits");
+  fmaxrr = pset.get<float>("maxrr");
 
   map_PhysdEdx[13] = new PhysdEdx(13); // == muon
   map_PhysdEdx[211] = new PhysdEdx(211); // == charged pion
@@ -79,6 +79,8 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
       float this_res = trkres[i];
       float this_pitch = trkpitches[i];
 
+      if(this_res > fmaxrr) continue;
+      
       // in MeV/c unit
       float p_mu = 1000.*tmc.GetTrackMomentum(this_res, 13);
       float p_pi = 1000.*tmc.GetTrackMomentum(this_res, 211);

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
@@ -27,8 +27,8 @@ pid::LikelihoodPIDAlg::LikelihoodPIDAlg(fhicl::ParameterSet const& pset)
 {
   fmaxrr = pset.get<float>("maxrr");
 
-  map_PhysdEdx[13] = new PhysdEdx(13); // == muon
-  map_PhysdEdx[211] = new PhysdEdx(211); // == charged pion
+  map_PhysdEdx[13] = new PhysdEdx(13);     // == muon
+  map_PhysdEdx[211] = new PhysdEdx(211);   // == charged pion
   map_PhysdEdx[2212] = new PhysdEdx(2212); // == proton
 }
 
@@ -57,7 +57,8 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
     if (i_calo == 0)
       plid = calo->PlaneID();
     else if (plid != calo->PlaneID())
-      throw cet::exception("LikelihoodPIDAlg") << "PlaneID mismatch: " << plid << ", " << calo->PlaneID();
+      throw cet::exception("LikelihoodPIDAlg")
+        << "PlaneID mismatch: " << plid << ", " << calo->PlaneID();
 
     int nptmu = 0;
     int nptpi = 0;
@@ -79,30 +80,32 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
       float this_res = trkres[i];
       float this_pitch = trkpitches[i];
 
-      if(this_res > fmaxrr) continue;
-      
-      // in MeV/c unit
-      float p_mu = 1000.*tmc.GetTrackMomentum(this_res, 13);
-      float p_pi = 1000.*tmc.GetTrackMomentum(this_res, 211);
-      float p_pro = 1000.*tmc.GetTrackMomentum(this_res, 2212);
+      if (this_res > fmaxrr) continue;
 
-      float ke_mu = map_PhysdEdx[13] -> MomentumtoKE(p_mu);
-      float ke_pi = map_PhysdEdx[13] -> MomentumtoKE(p_pi);
-      float ke_pro = map_PhysdEdx[13] -> MomentumtoKE(p_pro);
+      // in MeV/c unit
+      float p_mu = 1000. * tmc.GetTrackMomentum(this_res, 13);
+      float p_pi = 1000. * tmc.GetTrackMomentum(this_res, 211);
+      float p_pro = 1000. * tmc.GetTrackMomentum(this_res, 2212);
+
+      float ke_mu = map_PhysdEdx[13]->MomentumtoKE(p_mu);
+      float ke_pi = map_PhysdEdx[13]->MomentumtoKE(p_pi);
+      float ke_pro = map_PhysdEdx[13]->MomentumtoKE(p_pro);
 
       // == muon likelihoods
       double mu_pdf, mu_pdf_max;
-      bool mu_valid_pdf = map_PhysdEdx[13] -> dEdx_PDF(ke_mu, this_pitch, this_dedx, &mu_pdf, &mu_pdf_max);
-      if(mu_valid_pdf){
-	double this_lambdamu = 2. * (log(mu_pdf_max) - log(mu_pdf));
-	lambdamu += this_lambdamu;
-	++nptmu;
+      bool mu_valid_pdf =
+        map_PhysdEdx[13]->dEdx_PDF(ke_mu, this_pitch, this_dedx, &mu_pdf, &mu_pdf_max);
+      if (mu_valid_pdf) {
+        double this_lambdamu = 2. * (log(mu_pdf_max) - log(mu_pdf));
+        lambdamu += this_lambdamu;
+        ++nptmu;
       }
 
       // == pion likelihoods
       double pi_pdf, pi_pdf_max;
-      bool pi_valid_pdf = map_PhysdEdx[211] -> dEdx_PDF(ke_pi, this_pitch, this_dedx, &pi_pdf, &pi_pdf_max);
-      if(pi_valid_pdf){
+      bool pi_valid_pdf =
+        map_PhysdEdx[211]->dEdx_PDF(ke_pi, this_pitch, this_dedx, &pi_pdf, &pi_pdf_max);
+      if (pi_valid_pdf) {
         double this_lambdapi = 2. * (log(pi_pdf_max) - log(pi_pdf));
         lambdapi += this_lambdapi;
         ++nptpi;
@@ -110,8 +113,9 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
 
       // == proton likelihoods
       double pro_pdf, pro_pdf_max;
-      bool pro_valid_pdf = map_PhysdEdx[2212] -> dEdx_PDF(ke_pro, this_pitch, this_dedx, &pro_pdf, &pro_pdf_max);
-      if(pro_valid_pdf){
+      bool pro_valid_pdf =
+        map_PhysdEdx[2212]->dEdx_PDF(ke_pro, this_pitch, this_dedx, &pro_pdf, &pro_pdf_max);
+      if (pro_valid_pdf) {
         double this_lambdapro = 2. * (log(pro_pdf_max) - log(pro_pdf));
         lambdapro += this_lambdapro;
         ++nptpro;
@@ -122,7 +126,7 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
     anab::sParticleIDAlgScores lambdapion;
     anab::sParticleIDAlgScores lambdaproton;
 
-    if(nptmu){
+    if (nptmu) {
       lambdamuon.fAlgName = "Likelihood";
       lambdamuon.fVariableType = anab::kGOF;
       lambdamuon.fTrackDir = anab::kForward;
@@ -134,7 +138,7 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
       AlgScoresVec.push_back(lambdamuon);
     }
 
-    if(nptpi){
+    if (nptpi) {
       lambdapion.fAlgName = "Likelihood";
       lambdapion.fVariableType = anab::kGOF;
       lambdapion.fTrackDir = anab::kForward;
@@ -146,7 +150,7 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
       AlgScoresVec.push_back(lambdapion);
     }
 
-    if(nptpro){
+    if (nptpro) {
       lambdaproton.fAlgName = "Likelihood";
       lambdaproton.fVariableType = anab::kGOF;
       lambdaproton.fTrackDir = anab::kForward;

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
@@ -22,6 +22,12 @@
 
 #include "cetlib/pow.h"
 
+namespace {
+  constexpr float M_mu = 105.65837; // MeV
+  constexpr float M_pi = 139.570;   // MeV, charged pion
+  constexpr float M_pro = 938.272;  // MeV
+}
+
 //------------------------------------------------------------------------------
 pid::LikelihoodPIDAlg::LikelihoodPIDAlg(fhicl::ParameterSet const& pset)
 {

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
@@ -22,12 +22,6 @@
 
 #include "cetlib/pow.h"
 
-namespace {
-  constexpr float M_mu = 105.65837; // MeV
-  constexpr float M_pi = 139.570;   // MeV, charged pion
-  constexpr float M_pro = 938.272;  // MeV
-}
-
 //------------------------------------------------------------------------------
 pid::LikelihoodPIDAlg::LikelihoodPIDAlg(fhicl::ParameterSet const& pset)
 {

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
@@ -33,9 +33,9 @@ pid::LikelihoodPIDAlg::LikelihoodPIDAlg(fhicl::ParameterSet const& pset)
 {
   fmaxrr = pset.get<float>("maxrr");
 
-  map_PhysdEdx[13] = new PhysdEdx(13);     // == muon
-  map_PhysdEdx[211] = new PhysdEdx(211);   // == charged pion
-  map_PhysdEdx[2212] = new PhysdEdx(2212); // == proton
+  map_PhysdEdx[13] = std::make_unique<PhysdEdx>(13);     // == muon
+  map_PhysdEdx[211] = std::make_unique<PhysdEdx>(211);   // == charged pion
+  map_PhysdEdx[2212] = std::make_unique<PhysdEdx>(2212); // == proto
 }
 
 //------------------------------------------------------------------------------
@@ -103,8 +103,12 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
         map_PhysdEdx[13]->dEdx_PDF(ke_mu, this_pitch, this_dedx, &mu_pdf, &mu_pdf_max);
       if (mu_valid_pdf) {
         double this_lambdamu = 0.;
-        if (mu_pdf_max > 1e-6 && mu_pdf > 1e-6)
-          this_lambdamu = 2. * (log(mu_pdf_max) - log(mu_pdf));
+        if (mu_pdf_max > 1e-6) {
+          if (mu_pdf > 1e-6)
+            this_lambdamu = 2. * (log(mu_pdf_max) - log(mu_pdf));
+          else
+            this_lambdamu = 2. * (log(mu_pdf_max) - log(1e-6));
+        }
         lambdamu += this_lambdamu;
         ++nptmu;
       }
@@ -115,8 +119,12 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
         map_PhysdEdx[211]->dEdx_PDF(ke_pi, this_pitch, this_dedx, &pi_pdf, &pi_pdf_max);
       if (pi_valid_pdf) {
         double this_lambdapi = 0.;
-        if (pi_pdf_max > 1e-6 && pi_pdf > 1e-6)
-          this_lambdapi = 2. * (log(pi_pdf_max) - log(pi_pdf));
+        if (pi_pdf_max > 1e-6) {
+          if (pi_pdf > 1e-6)
+            this_lambdapi = 2. * (log(pi_pdf_max) - log(pi_pdf));
+          else
+            this_lambdapi = 2. * (log(pi_pdf_max) - log(1e-6));
+        }
         lambdapi += this_lambdapi;
         ++nptpi;
       }
@@ -127,8 +135,12 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
         map_PhysdEdx[2212]->dEdx_PDF(ke_pro, this_pitch, this_dedx, &pro_pdf, &pro_pdf_max);
       if (pro_valid_pdf) {
         double this_lambdapro = 0.;
-        if (pro_pdf_max > 1e-6 && pro_pdf > 1e-6)
-          this_lambdapro = 2. * (log(pro_pdf_max) - log(pro_pdf));
+        if (pro_pdf_max > 1e-6) {
+          if (pro_pdf > 1e-6)
+            this_lambdapro = 2. * (log(pro_pdf_max) - log(pro_pdf));
+          else
+            this_lambdapro = 2. * (log(pro_pdf_max) - log(1e-6));
+        }
         lambdapro += this_lambdapro;
         ++nptpro;
       }

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
@@ -96,7 +96,9 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
       bool mu_valid_pdf =
         map_PhysdEdx[13]->dEdx_PDF(ke_mu, this_pitch, this_dedx, &mu_pdf, &mu_pdf_max);
       if (mu_valid_pdf) {
-        double this_lambdamu = 2. * (log(mu_pdf_max) - log(mu_pdf));
+        double this_lambdamu = 0.;
+        if (mu_pdf_max > 1e-6 && mu_pdf > 1e-6)
+          this_lambdamu = 2. * (log(mu_pdf_max) - log(mu_pdf));
         lambdamu += this_lambdamu;
         ++nptmu;
       }
@@ -106,7 +108,9 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
       bool pi_valid_pdf =
         map_PhysdEdx[211]->dEdx_PDF(ke_pi, this_pitch, this_dedx, &pi_pdf, &pi_pdf_max);
       if (pi_valid_pdf) {
-        double this_lambdapi = 2. * (log(pi_pdf_max) - log(pi_pdf));
+        double this_lambdapi = 0.;
+        if (pi_pdf_max > 1e-6 && pi_pdf > 1e-6)
+          this_lambdapi = 2. * (log(pi_pdf_max) - log(pi_pdf));
         lambdapi += this_lambdapi;
         ++nptpi;
       }
@@ -116,7 +120,9 @@ anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
       bool pro_valid_pdf =
         map_PhysdEdx[2212]->dEdx_PDF(ke_pro, this_pitch, this_dedx, &pro_pdf, &pro_pdf_max);
       if (pro_valid_pdf) {
-        double this_lambdapro = 2. * (log(pro_pdf_max) - log(pro_pdf));
+        double this_lambdapro = 0.;
+        if (pro_pdf_max > 1e-6 && pro_pdf > 1e-6)
+          this_lambdapro = 2. * (log(pro_pdf_max) - log(pro_pdf));
         lambdapro += this_lambdapro;
         ++nptpro;
       }

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.cxx
@@ -1,0 +1,163 @@
+////////////////////////////////////////////////////////////////////////
+//
+// A likelihood based particleID
+//
+// sungbino@fnal.gov
+//
+////////////////////////////////////////////////////////////////////////
+#include "larana/ParticleIdentification/LikelihoodPIDAlg.h"
+#include "lardataobj/AnalysisBase/Calorimetry.h"
+#include "lardataobj/AnalysisBase/ParticleID.h"
+
+// ROOT includes
+#include "TFile.h"
+#include "TMath.h"
+#include "TProfile.h"
+
+// Framework includes
+#include "canvas/Persistency/Common/Ptr.h"
+#include "cetlib/search_path.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "lardata/Utilities/GeometryUtilities.h"
+
+#include "cetlib/pow.h"
+
+//------------------------------------------------------------------------------
+pid::LikelihoodPIDAlg::LikelihoodPIDAlg(fhicl::ParameterSet const& pset)
+{
+  fSkipNhits = pset.get<int>("SkipNhits");
+
+  map_PhysdEdx[13] = new PhysdEdx(13); // == muon
+  map_PhysdEdx[211] = new PhysdEdx(211); // == charged pion
+  map_PhysdEdx[2212] = new PhysdEdx(2212); // == proton
+}
+
+//------------------------------------------------------------------------------
+std::bitset<8> pid::LikelihoodPIDAlg::GetBitset(geo::PlaneID planeID)
+{
+
+  std::bitset<8> thisBitset;
+
+  thisBitset.set(planeID.Plane);
+
+  return thisBitset;
+}
+
+//------------------------------------------------------------------------------
+anab::ParticleID pid::LikelihoodPIDAlg::DoParticleID(
+  const std::vector<art::Ptr<anab::Calorimetry>>& calos)
+{
+
+  std::vector<anab::sParticleIDAlgScores> AlgScoresVec;
+  geo::PlaneID plid;
+
+  for (size_t i_calo = 0; i_calo < calos.size(); i_calo++) {
+
+    art::Ptr<anab::Calorimetry> calo = calos.at(i_calo);
+    if (i_calo == 0)
+      plid = calo->PlaneID();
+    else if (plid != calo->PlaneID())
+      throw cet::exception("LikelihoodPIDAlg") << "PlaneID mismatch: " << plid << ", " << calo->PlaneID();
+
+    int nptmu = 0;
+    int nptpi = 0;
+    int nptpro = 0;
+
+    double lambdamu = 0;
+    double lambdapi = 0;
+    double lambdapro = 0;
+
+    std::vector<float> trkdedx = calo->dEdx();
+    std::vector<float> trkres = calo->ResidualRange();
+    std::vector<float> trkpitches = calo->TrkPitchVec();
+
+    for (unsigned i = 0; i < trkdedx.size(); ++i) { //hits
+      //ignore the first and the last point
+      if (i == 0 || i == trkdedx.size() - 1) continue;
+
+      float this_dedx = trkdedx[i];
+      float this_res = trkres[i];
+      float this_pitch = trkpitches[i];
+
+      // in MeV/c unit
+      float p_mu = 1000.*tmc.GetTrackMomentum(this_res, 13);
+      float p_pi = 1000.*tmc.GetTrackMomentum(this_res, 211);
+      float p_pro = 1000.*tmc.GetTrackMomentum(this_res, 2212);
+
+      float ke_mu = map_PhysdEdx[13] -> MomentumtoKE(p_mu);
+      float ke_pi = map_PhysdEdx[13] -> MomentumtoKE(p_pi);
+      float ke_pro = map_PhysdEdx[13] -> MomentumtoKE(p_pro);
+
+      // == muon likelihoods
+      double mu_pdf, mu_pdf_max;
+      bool mu_valid_pdf = map_PhysdEdx[13] -> dEdx_PDF(ke_mu, this_pitch, this_dedx, &mu_pdf, &mu_pdf_max);
+      if(mu_valid_pdf){
+	double this_lambdamu = 2. * (log(mu_pdf_max) - log(mu_pdf));
+	lambdamu += this_lambdamu;
+	++nptmu;
+      }
+
+      // == pion likelihoods
+      double pi_pdf, pi_pdf_max;
+      bool pi_valid_pdf = map_PhysdEdx[211] -> dEdx_PDF(ke_pi, this_pitch, this_dedx, &pi_pdf, &pi_pdf_max);
+      if(pi_valid_pdf){
+        double this_lambdapi = 2. * (log(pi_pdf_max) - log(pi_pdf));
+        lambdapi += this_lambdapi;
+        ++nptpi;
+      }
+
+      // == proton likelihoods
+      double pro_pdf, pro_pdf_max;
+      bool pro_valid_pdf = map_PhysdEdx[2212] -> dEdx_PDF(ke_pro, this_pitch, this_dedx, &pro_pdf, &pro_pdf_max);
+      if(pro_valid_pdf){
+        double this_lambdapro = 2. * (log(pro_pdf_max) - log(pro_pdf));
+        lambdapro += this_lambdapro;
+        ++nptpro;
+      }
+    }
+
+    anab::sParticleIDAlgScores lambdamuon;
+    anab::sParticleIDAlgScores lambdapion;
+    anab::sParticleIDAlgScores lambdaproton;
+
+    if(nptmu){
+      lambdamuon.fAlgName = "Likelihood";
+      lambdamuon.fVariableType = anab::kGOF;
+      lambdamuon.fTrackDir = anab::kForward;
+      lambdamuon.fAssumedPdg = 13;
+      lambdamuon.fPlaneMask = GetBitset(calo->PlaneID());
+      lambdamuon.fNdf = nptmu;
+      lambdamuon.fValue = lambdamu / nptmu;
+
+      AlgScoresVec.push_back(lambdamuon);
+    }
+
+    if(nptpi){
+      lambdapion.fAlgName = "Likelihood";
+      lambdapion.fVariableType = anab::kGOF;
+      lambdapion.fTrackDir = anab::kForward;
+      lambdapion.fAssumedPdg = 221;
+      lambdapion.fPlaneMask = GetBitset(calo->PlaneID());
+      lambdapion.fNdf = nptpi;
+      lambdapion.fValue = lambdapi / nptpi;
+
+      AlgScoresVec.push_back(lambdapion);
+    }
+
+    if(nptpro){
+      lambdaproton.fAlgName = "Likelihood";
+      lambdaproton.fVariableType = anab::kGOF;
+      lambdaproton.fTrackDir = anab::kForward;
+      lambdaproton.fAssumedPdg = 2212;
+      lambdaproton.fPlaneMask = GetBitset(calo->PlaneID());
+      lambdaproton.fNdf = nptpro;
+      lambdaproton.fValue = lambdapro / nptpro;
+
+      AlgScoresVec.push_back(lambdaproton);
+    }
+  }
+
+  anab::ParticleID pidOut(AlgScoresVec, plid);
+
+  return pidOut;
+}

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.h
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.h
@@ -44,7 +44,7 @@ namespace pid {
     anab::ParticleID DoParticleID(const std::vector<art::Ptr<anab::Calorimetry>>& calo);
 
   private:
-    std::map<int, PhysdEdx*> map_PhysdEdx;
+    std::map<int, std::unique_ptr<PhysdEdx>> map_PhysdEdx;
     trkf::TrackMomentumCalculator tmc;
     float fmaxrr;
   }; //

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.h
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.h
@@ -13,9 +13,8 @@
 #include <optional>
 #include <string>
 
-namespace fhicl {
-  class ParameterSet;
-}
+#include "fhiclcpp/fwd.h"
+
 #include "canvas/Persistency/Common/Ptr.h"
 #include "larana/ParticleIdentification/PhysdEdx.h"
 
@@ -46,11 +45,6 @@ namespace pid {
 
   private:
     std::map<int, PhysdEdx*> map_PhysdEdx;
-
-    float M_mu = 105.65837; // MeV
-    float M_pi = 139.570;   // MeV, charged pion
-    float M_pro = 938.272;  // MeV
-
     trkf::TrackMomentumCalculator tmc;
     float fmaxrr;
   }; //

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.h
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.h
@@ -52,8 +52,7 @@ namespace pid {
     float M_pro = 938.272; // MeV
     
     trkf::TrackMomentumCalculator tmc;
-    int fSkipNhits;
-
+    float fmaxrr;
   }; //
 } // namespace
 #endif // LIKELIHOODPIDALG_H

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.h
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.h
@@ -1,0 +1,59 @@
+////////////////////////////////////////////////////////////////////////
+//
+// A likelihood based particleID
+//
+// sungbino@fnal.gov
+//
+////////////////////////////////////////////////////////////////////////
+#ifndef LIKELIHOODPIDALG_H
+#define LIKELIHOODPIDALG_H
+
+#include <bitset>
+#include <optional>
+#include <string>
+#include <cmath>
+
+namespace fhicl {
+  class ParameterSet;
+}
+#include "larana/ParticleIdentification/PhysdEdx.h"
+#include "canvas/Persistency/Common/Ptr.h"
+
+#include "larreco/RecoAlg/TrackMomentumCalculator.h"
+
+#include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
+
+class TProfile;
+
+namespace anab {
+  class Calorimetry;
+  class ParticleID;
+}
+
+namespace pid {
+
+  class LikelihoodPIDAlg {
+
+  public:
+    LikelihoodPIDAlg(fhicl::ParameterSet const& pset);
+
+    /**
+     * Helper function to go from geo::PlaneID to a bitset
+     */
+    std::bitset<8> GetBitset(geo::PlaneID planeID);
+
+    anab::ParticleID DoParticleID(const std::vector<art::Ptr<anab::Calorimetry>>& calo);
+
+  private:
+    std::map< int, PhysdEdx* > map_PhysdEdx;
+
+    float M_mu = 105.65837; // MeV
+    float M_pi = 139.570; // MeV, charged pion
+    float M_pro = 938.272; // MeV
+    
+    trkf::TrackMomentumCalculator tmc;
+    int fSkipNhits;
+
+  }; //
+} // namespace
+#endif // LIKELIHOODPIDALG_H

--- a/larana/ParticleIdentification/LikelihoodPIDAlg.h
+++ b/larana/ParticleIdentification/LikelihoodPIDAlg.h
@@ -9,15 +9,15 @@
 #define LIKELIHOODPIDALG_H
 
 #include <bitset>
+#include <cmath>
 #include <optional>
 #include <string>
-#include <cmath>
 
 namespace fhicl {
   class ParameterSet;
 }
-#include "larana/ParticleIdentification/PhysdEdx.h"
 #include "canvas/Persistency/Common/Ptr.h"
+#include "larana/ParticleIdentification/PhysdEdx.h"
 
 #include "larreco/RecoAlg/TrackMomentumCalculator.h"
 
@@ -45,12 +45,12 @@ namespace pid {
     anab::ParticleID DoParticleID(const std::vector<art::Ptr<anab::Calorimetry>>& calo);
 
   private:
-    std::map< int, PhysdEdx* > map_PhysdEdx;
+    std::map<int, PhysdEdx*> map_PhysdEdx;
 
     float M_mu = 105.65837; // MeV
-    float M_pi = 139.570; // MeV, charged pion
-    float M_pro = 938.272; // MeV
-    
+    float M_pi = 139.570;   // MeV, charged pion
+    float M_pro = 938.272;  // MeV
+
     trkf::TrackMomentumCalculator tmc;
     float fmaxrr;
   }; //

--- a/larana/ParticleIdentification/LikelihoodParticleID_module.cc
+++ b/larana/ParticleIdentification/LikelihoodParticleID_module.cc
@@ -39,11 +39,11 @@ private:
 };
 
 pid::LikelihoodParticleID::LikelihoodParticleID(fhicl::ParameterSet const& p)
-  : EDProducer{p}, fLikelihoodAlg(p.get<fhicl::ParameterSet>("LikelihoodPIDAlg"))
+  : EDProducer{p}
+  , fTrackModuleLabel(p.get<std::string>("TrackModuleLabel"))
+  , fCalorimetryModuleLabel(p.get<std::string>("CalorimetryModuleLabel"))
+  , fLikelihoodAlg(p.get<fhicl::ParameterSet>("LikelihoodPIDAlg"))
 {
-  fTrackModuleLabel = p.get<std::string>("TrackModuleLabel");
-  fCalorimetryModuleLabel = p.get<std::string>("CalorimetryModuleLabel");
-
   produces<std::vector<anab::ParticleID>>();
   produces<art::Assns<recob::Track, anab::ParticleID>>();
 }

--- a/larana/ParticleIdentification/LikelihoodParticleID_module.cc
+++ b/larana/ParticleIdentification/LikelihoodParticleID_module.cc
@@ -1,0 +1,84 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// \brief A likelihood based particle identification method using calorimetry information
+//
+// \author sungbino@fnal.gov
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "larana/ParticleIdentification/LikelihoodPIDAlg.h"
+#include "lardata/Utilities/AssociationUtil.h"
+#include "lardataobj/AnalysisBase/ParticleID.h"
+#include "lardataobj/RecoBase/Track.h"
+
+// Framework includes
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "canvas/Persistency/Common/FindManyP.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "fhiclcpp/ParameterSet.h"
+
+namespace pid {
+  class LikelihoodParticleID;
+}
+
+class pid::LikelihoodParticleID : public art::EDProducer {
+public:
+  explicit LikelihoodParticleID(fhicl::ParameterSet const& p);
+
+  virtual void produce(art::Event& e);
+
+private:
+  std::string fTrackModuleLabel;
+  std::string fCalorimetryModuleLabel;
+
+  LikelihoodPIDAlg fLikelihoodAlg;
+};
+
+pid::LikelihoodParticleID::LikelihoodParticleID(fhicl::ParameterSet const& p)
+  : EDProducer{p}, fLikelihoodAlg(p.get<fhicl::ParameterSet>("LikelihoodPIDAlg"))
+{
+  fTrackModuleLabel = p.get<std::string>("TrackModuleLabel");
+  fCalorimetryModuleLabel = p.get<std::string>("CalorimetryModuleLabel");
+
+  produces<std::vector<anab::ParticleID>>();
+  produces<art::Assns<recob::Track, anab::ParticleID>>();
+}
+
+void pid::LikelihoodParticleID::produce(art::Event& evt)
+{
+  art::Handle<std::vector<recob::Track>> trackListHandle;
+  evt.getByLabel(fTrackModuleLabel, trackListHandle);
+
+  std::vector<art::Ptr<recob::Track>> tracklist;
+  art::fill_ptr_vector(tracklist, trackListHandle);
+
+  art::FindManyP<anab::Calorimetry> fmcal(trackListHandle, evt, fCalorimetryModuleLabel);
+
+  //if (!fmcal.isValid()) return;
+
+  std::unique_ptr<std::vector<anab::ParticleID>> particleidcol(new std::vector<anab::ParticleID>);
+  std::unique_ptr<art::Assns<recob::Track, anab::ParticleID>> assn(
+    new art::Assns<recob::Track, anab::ParticleID>);
+
+  if (fmcal.isValid()) {
+    std::vector<art::Ptr<anab::Calorimetry>> calovec(1, art::Ptr<anab::Calorimetry>());
+    for (size_t trkIter = 0; trkIter < tracklist.size(); ++trkIter) {
+      for (size_t i = 0; i < fmcal.at(trkIter).size(); ++i) {
+        calovec[0] = fmcal.at(trkIter)[i];
+        anab::ParticleID pidout = fLikelihoodAlg.DoParticleID(calovec);
+        particleidcol->push_back(pidout);
+        util::CreateAssn(evt, *particleidcol, tracklist[trkIter], *assn);
+      }
+    }
+  }
+  evt.put(std::move(particleidcol));
+  evt.put(std::move(assn));
+
+  return;
+}
+
+DEFINE_ART_MODULE(pid::LikelihoodParticleID)

--- a/larana/ParticleIdentification/PhysdEdx.cxx
+++ b/larana/ParticleIdentification/PhysdEdx.cxx
@@ -1,0 +1,204 @@
+////////////////////////////////////////////////////////////////////////
+//
+// A class for dE/dx functions for likelihood based particleID
+//
+// sungbino@fnal.gov
+//
+////////////////////////////////////////////////////////////////////////
+#include "PhysdEdx.h"
+#include "TSpline.h"
+#include <iostream>
+#include <cmath>
+#include <algorithm>
+
+#include "cetlib/pow.h"
+
+ROOT::Math::VavilovAccurate vav;
+
+pid::PhysdEdx::PhysdEdx()
+  : pdgcode(0)
+  , mass(0)
+  , charge(0){
+}
+
+pid::PhysdEdx::PhysdEdx(int pdg)
+  : pdgcode(0)
+  , mass(0)
+  , charge(0){
+  SetPdgCode(pdg);
+}
+
+void pid::PhysdEdx::SetPdgCode(int pdg){
+
+  pdgcode = pdg;
+
+  if (abs(pdgcode) == 13){//muon
+    mass = 105.6583755;
+    charge = 1;
+  }
+  else if (abs(pdgcode) == 211){//pion
+    mass = 139.57039;
+    charge = 1;
+  }
+  else if (abs(pdgcode) == 321){//kaon
+    mass = 493.677;
+    charge = 1;
+  }
+  else if (pdgcode == 2212){//proton
+    mass = 938.27208816;
+    charge = 1;
+  }
+  else{
+    throw cet::exception("PhysdEdx") << "Unknown pdg code "<< pdgcode;
+    exit(1);
+  }
+
+}
+
+double pid::PhysdEdx::densityEffect(double beta, double gamma){
+  // == Estimate the density correction
+  double density_y = TMath::Log10(beta * gamma);
+  double ln10 = TMath::Log(10);
+  double this_delta = 0.;
+  if(density_y > density_y1){
+    this_delta = 2.0 * ln10 * density_y - density_C;
+  }
+  else if (density_y < density_y0){
+    this_delta = 0.;
+  }
+  else{
+    this_delta = 2.0 * ln10 * density_y - density_C + density_a * pow(density_y1 - density_y, density_k);
+  }
+
+  return this_delta;
+}
+
+double pid::PhysdEdx::betaGamma(double KE){
+
+  double gamma, beta;
+  gamma = (KE + mass) / mass;
+  beta = sqrt( 1 - 1/pow(gamma,2));
+   
+  return beta*gamma;
+}
+
+double pid::PhysdEdx::Landau_xi(double KE, double pitch){
+  double gamma = (KE/mass)+1.0;
+  double beta = TMath::Sqrt(1-(1.0/(gamma*gamma)));
+  double xi = rho * pitch * 0.5 * K * (Z / A) * pow(1. / beta, 2);
+  return xi;
+}
+
+double pid::PhysdEdx::Get_Wmax(double KE){
+  double gamma = (KE/mass)+1.0;
+  double beta = TMath::Sqrt(1-(1.0/(gamma*gamma)));
+  double Wmax = (2.0 * me * pow(beta * gamma, 2)) / (1.0 + 2.0 * me * (gamma / mass) + pow((me / mass),2));
+
+  return Wmax;
+}
+
+double pid::PhysdEdx::meandEdx(double KE){
+
+  double gamma = (KE + mass) / mass;
+  double beta = sqrt( 1 - 1/pow(gamma,2));
+  double wmax = Get_Wmax(KE);
+  double dEdX = (rho*K*Z*pow(charge,2))/(A*pow(beta,2))*(0.5*log(2*me*pow(gamma,2)*pow(beta,2)*wmax/pow(I,2)) - pow(beta,2) - densityEffect( beta, gamma )/2 );
+
+  return dEdX;
+}
+
+double pid::PhysdEdx::MPVdEdx(double KE, double pitch){
+
+  //KE is kinetic energy in MeV
+  //pitch is in cm
+  double gamma = (KE + mass) / mass;
+  double beta = sqrt( 1 - 1/pow(gamma,2));
+
+  double xi = Landau_xi(KE, pitch);
+  
+  double eloss_mpv = xi*(log( 2*me*pow(gamma,2)*pow(beta,2) / I ) + log( xi / I ) + 0.2 - pow(beta,2) - densityEffect( beta, gamma ) )/pitch;
+
+  return eloss_mpv;
+}
+
+double pid::PhysdEdx::KEtoMomentum(double KE){
+  return sqrt(pow(KE, 2) + 2.0 * KE * mass);
+}
+
+double pid::PhysdEdx::MomentumtoKE(double momentum){
+  return sqrt(pow(momentum, 2) + pow(mass, 2)) - mass;
+}
+
+double dEdx_PDF_fuction(double *x, double *par){
+  // == par[5] = {kappa, beta^2, xi, <dE/dx>BB, width}
+  double a = par[2] / par[4];
+  double b = (0.422784 + par[1] + log(par[0])) * par[2] / par[4] + par[3];
+  double y = (x[0] - b) / a;
+
+  double this_vav = 0.;
+
+  if(par[0] < 0.01){ // == Landau
+    this_vav = TMath::Landau(y);
+    this_vav =  this_vav / a;
+  }
+  else if(par[0] > 10.){ // == Gaussian
+    double mu = vav.Mean(par[0], par[1]);
+    double sigma = sqrt(vav.Variance(par[0], par[1]));
+    this_vav =  TMath::Gaus(y, mu, sigma);
+  }
+  else{ // == Vavilov
+    this_vav =  vav.Pdf(y, par[0], par[1]);
+    this_vav =  this_vav / a;
+  }
+
+  return this_vav;
+}
+
+bool pid::PhysdEdx::dEdx_PDF(double KE, double pitch, double dEdx, double *PDF_y, double *PDF_maxy){
+
+  double gamma = (KE/mass)+1.0;
+  double beta = TMath::Sqrt(1-(1.0/(gamma*gamma)));
+  double this_xi = Landau_xi(KE, pitch);
+  double this_Wmax = Get_Wmax(KE);
+  double this_kappa = this_xi / this_Wmax;
+  double this_dEdx_BB = meandEdx(KE);
+  double par[5] = {this_kappa, beta * beta, this_xi, this_dEdx_BB, pitch};
+
+  TF1 *PDF = new TF1("", dEdx_PDF_fuction, 0., 50., 5);
+  PDF -> SetParameters(par[0], par[1], par[2], par[3], par[4]);
+  double this_PDF_y = PDF -> Eval(dEdx);
+  PDF_y[0] = this_PDF_y;
+
+  if(par[0] > 0.01 && par[0] < 10.){
+    double mu = vav.Mean(par[0], par[1]);
+    double sigma = sqrt(vav.Variance(par[0], par[1]));
+    TF1 *PDF_narrow = new TF1("PDF_narrow", dEdx_PDF_fuction, mu - sigma, mu + sigma, 5);
+    PDF_narrow -> SetParameters(par[0], par[1], par[2], par[3], par[4]);
+    PDF_maxy[0] = PDF_narrow -> GetMaximum();
+    delete PDF_narrow;
+  }
+  else{
+    PDF_maxy[0] = PDF -> GetMaximum();
+  }
+
+  delete PDF;
+  if(this_PDF_y > 0.) return true;
+  else return false;
+}
+
+double pid::PhysdEdx::dEdx_Gaus_Sigma(double KE, double pitch){
+
+  double gamma = (KE/mass)+1.0;
+  double beta = TMath::Sqrt(1-(1.0/(gamma*gamma)));
+  double this_xi = Landau_xi(KE, pitch);
+  double this_Wmax = Get_Wmax(KE);
+  double this_kappa = this_xi / this_Wmax;
+
+  double sigma = sqrt(vav.Variance(this_kappa, beta * beta));
+
+  return sigma;
+}
+
+pid::PhysdEdx::~PhysdEdx(){
+
+}

--- a/larana/ParticleIdentification/PhysdEdx.cxx
+++ b/larana/ParticleIdentification/PhysdEdx.cxx
@@ -40,19 +40,19 @@ void pid::PhysdEdx::SetPdgCode(int pdg)
   pdgcode = pdg;
 
   if (abs(pdgcode) == 13) { //muon
-    mass = 105.6583755;
+    mass = 105.6583755; // MeV
     charge = 1;
   }
   else if (abs(pdgcode) == 211) { //pion
-    mass = 139.57039;
+    mass = 139.57039; // MeV
     charge = 1;
   }
   else if (abs(pdgcode) == 321) { //kaon
-    mass = 493.677;
+    mass = 493.677; // MeV
     charge = 1;
   }
   else if (pdgcode == 2212) { //proton
-    mass = 938.27208816;
+    mass = 938.27208816; // MeV
     charge = 1;
   }
   else {

--- a/larana/ParticleIdentification/PhysdEdx.cxx
+++ b/larana/ParticleIdentification/PhysdEdx.cxx
@@ -7,129 +7,137 @@
 ////////////////////////////////////////////////////////////////////////
 #include "PhysdEdx.h"
 #include "TSpline.h"
-#include <iostream>
-#include <cmath>
 #include <algorithm>
+#include <cmath>
+#include <iostream>
 
 #include "cetlib/pow.h"
 
 ROOT::Math::VavilovAccurate vav;
 
-pid::PhysdEdx::PhysdEdx()
-  : pdgcode(0)
-  , mass(0)
-  , charge(0){
-}
+pid::PhysdEdx::PhysdEdx() : pdgcode(0), mass(0), charge(0) {}
 
-pid::PhysdEdx::PhysdEdx(int pdg)
-  : pdgcode(0)
-  , mass(0)
-  , charge(0){
+pid::PhysdEdx::PhysdEdx(int pdg) : pdgcode(0), mass(0), charge(0)
+{
   SetPdgCode(pdg);
 }
 
-void pid::PhysdEdx::SetPdgCode(int pdg){
+void pid::PhysdEdx::SetPdgCode(int pdg)
+{
 
   pdgcode = pdg;
 
-  if (abs(pdgcode) == 13){//muon
+  if (abs(pdgcode) == 13) { //muon
     mass = 105.6583755;
     charge = 1;
   }
-  else if (abs(pdgcode) == 211){//pion
+  else if (abs(pdgcode) == 211) { //pion
     mass = 139.57039;
     charge = 1;
   }
-  else if (abs(pdgcode) == 321){//kaon
+  else if (abs(pdgcode) == 321) { //kaon
     mass = 493.677;
     charge = 1;
   }
-  else if (pdgcode == 2212){//proton
+  else if (pdgcode == 2212) { //proton
     mass = 938.27208816;
     charge = 1;
   }
-  else{
-    throw cet::exception("PhysdEdx") << "Unknown pdg code "<< pdgcode;
+  else {
+    throw cet::exception("PhysdEdx") << "Unknown pdg code " << pdgcode;
     exit(1);
   }
-
 }
 
-double pid::PhysdEdx::densityEffect(double beta, double gamma){
+double pid::PhysdEdx::densityEffect(double beta, double gamma)
+{
   // == Estimate the density correction
   double density_y = TMath::Log10(beta * gamma);
   double ln10 = TMath::Log(10);
   double this_delta = 0.;
-  if(density_y > density_y1){
-    this_delta = 2.0 * ln10 * density_y - density_C;
-  }
-  else if (density_y < density_y0){
+  if (density_y > density_y1) { this_delta = 2.0 * ln10 * density_y - density_C; }
+  else if (density_y < density_y0) {
     this_delta = 0.;
   }
-  else{
-    this_delta = 2.0 * ln10 * density_y - density_C + density_a * pow(density_y1 - density_y, density_k);
+  else {
+    this_delta =
+      2.0 * ln10 * density_y - density_C + density_a * pow(density_y1 - density_y, density_k);
   }
 
   return this_delta;
 }
 
-double pid::PhysdEdx::betaGamma(double KE){
+double pid::PhysdEdx::betaGamma(double KE)
+{
 
   double gamma, beta;
   gamma = (KE + mass) / mass;
-  beta = sqrt( 1 - 1/pow(gamma,2));
-   
-  return beta*gamma;
+  beta = sqrt(1 - 1 / pow(gamma, 2));
+
+  return beta * gamma;
 }
 
-double pid::PhysdEdx::Landau_xi(double KE, double pitch){
-  double gamma = (KE/mass)+1.0;
-  double beta = TMath::Sqrt(1-(1.0/(gamma*gamma)));
+double pid::PhysdEdx::Landau_xi(double KE, double pitch)
+{
+  double gamma = (KE / mass) + 1.0;
+  double beta = TMath::Sqrt(1 - (1.0 / (gamma * gamma)));
   double xi = rho * pitch * 0.5 * K * (Z / A) * pow(1. / beta, 2);
   return xi;
 }
 
-double pid::PhysdEdx::Get_Wmax(double KE){
-  double gamma = (KE/mass)+1.0;
-  double beta = TMath::Sqrt(1-(1.0/(gamma*gamma)));
-  double Wmax = (2.0 * me * pow(beta * gamma, 2)) / (1.0 + 2.0 * me * (gamma / mass) + pow((me / mass),2));
+double pid::PhysdEdx::Get_Wmax(double KE)
+{
+  double gamma = (KE / mass) + 1.0;
+  double beta = TMath::Sqrt(1 - (1.0 / (gamma * gamma)));
+  double Wmax =
+    (2.0 * me * pow(beta * gamma, 2)) / (1.0 + 2.0 * me * (gamma / mass) + pow((me / mass), 2));
 
   return Wmax;
 }
 
-double pid::PhysdEdx::meandEdx(double KE){
+double pid::PhysdEdx::meandEdx(double KE)
+{
 
   double gamma = (KE + mass) / mass;
-  double beta = sqrt( 1 - 1/pow(gamma,2));
+  double beta = sqrt(1 - 1 / pow(gamma, 2));
   double wmax = Get_Wmax(KE);
-  double dEdX = (rho*K*Z*pow(charge,2))/(A*pow(beta,2))*(0.5*log(2*me*pow(gamma,2)*pow(beta,2)*wmax/pow(I,2)) - pow(beta,2) - densityEffect( beta, gamma )/2 );
+  double dEdX = (rho * K * Z * pow(charge, 2)) / (A * pow(beta, 2)) *
+                (0.5 * log(2 * me * pow(gamma, 2) * pow(beta, 2) * wmax / pow(I, 2)) -
+                 pow(beta, 2) - densityEffect(beta, gamma) / 2);
 
   return dEdX;
 }
 
-double pid::PhysdEdx::MPVdEdx(double KE, double pitch){
+double pid::PhysdEdx::MPVdEdx(double KE, double pitch)
+{
 
   //KE is kinetic energy in MeV
   //pitch is in cm
   double gamma = (KE + mass) / mass;
-  double beta = sqrt( 1 - 1/pow(gamma,2));
+  double beta = sqrt(1 - 1 / pow(gamma, 2));
 
   double xi = Landau_xi(KE, pitch);
-  
-  double eloss_mpv = xi*(log( 2*me*pow(gamma,2)*pow(beta,2) / I ) + log( xi / I ) + 0.2 - pow(beta,2) - densityEffect( beta, gamma ) )/pitch;
+
+  double eloss_mpv = xi *
+                     (log(2 * me * pow(gamma, 2) * pow(beta, 2) / I) + log(xi / I) + 0.2 -
+                      pow(beta, 2) - densityEffect(beta, gamma)) /
+                     pitch;
 
   return eloss_mpv;
 }
 
-double pid::PhysdEdx::KEtoMomentum(double KE){
+double pid::PhysdEdx::KEtoMomentum(double KE)
+{
   return sqrt(pow(KE, 2) + 2.0 * KE * mass);
 }
 
-double pid::PhysdEdx::MomentumtoKE(double momentum){
+double pid::PhysdEdx::MomentumtoKE(double momentum)
+{
   return sqrt(pow(momentum, 2) + pow(mass, 2)) - mass;
 }
 
-double dEdx_PDF_fuction(double *x, double *par){
+double dEdx_PDF_fuction(double* x, double* par)
+{
   // == par[5] = {kappa, beta^2, xi, <dE/dx>BB, width}
   double a = par[2] / par[4];
   double b = (0.422784 + par[1] + log(par[0])) * par[2] / par[4] + par[3];
@@ -137,59 +145,63 @@ double dEdx_PDF_fuction(double *x, double *par){
 
   double this_vav = 0.;
 
-  if(par[0] < 0.01){ // == Landau
+  if (par[0] < 0.01) { // == Landau
     this_vav = TMath::Landau(y);
-    this_vav =  this_vav / a;
+    this_vav = this_vav / a;
   }
-  else if(par[0] > 10.){ // == Gaussian
+  else if (par[0] > 10.) { // == Gaussian
     double mu = vav.Mean(par[0], par[1]);
     double sigma = sqrt(vav.Variance(par[0], par[1]));
-    this_vav =  TMath::Gaus(y, mu, sigma);
+    this_vav = TMath::Gaus(y, mu, sigma);
   }
-  else{ // == Vavilov
-    this_vav =  vav.Pdf(y, par[0], par[1]);
-    this_vav =  this_vav / a;
+  else { // == Vavilov
+    this_vav = vav.Pdf(y, par[0], par[1]);
+    this_vav = this_vav / a;
   }
 
   return this_vav;
 }
 
-bool pid::PhysdEdx::dEdx_PDF(double KE, double pitch, double dEdx, double *PDF_y, double *PDF_maxy){
+bool pid::PhysdEdx::dEdx_PDF(double KE, double pitch, double dEdx, double* PDF_y, double* PDF_maxy)
+{
 
-  double gamma = (KE/mass)+1.0;
-  double beta = TMath::Sqrt(1-(1.0/(gamma*gamma)));
+  double gamma = (KE / mass) + 1.0;
+  double beta = TMath::Sqrt(1 - (1.0 / (gamma * gamma)));
   double this_xi = Landau_xi(KE, pitch);
   double this_Wmax = Get_Wmax(KE);
   double this_kappa = this_xi / this_Wmax;
   double this_dEdx_BB = meandEdx(KE);
   double par[5] = {this_kappa, beta * beta, this_xi, this_dEdx_BB, pitch};
 
-  TF1 *PDF = new TF1("", dEdx_PDF_fuction, 0., 50., 5);
-  PDF -> SetParameters(par[0], par[1], par[2], par[3], par[4]);
-  double this_PDF_y = PDF -> Eval(dEdx);
+  TF1* PDF = new TF1("", dEdx_PDF_fuction, 0., 50., 5);
+  PDF->SetParameters(par[0], par[1], par[2], par[3], par[4]);
+  double this_PDF_y = PDF->Eval(dEdx);
   PDF_y[0] = this_PDF_y;
 
-  if(par[0] > 0.01 && par[0] < 10.){
+  if (par[0] > 0.01 && par[0] < 10.) {
     double mu = vav.Mean(par[0], par[1]);
     double sigma = sqrt(vav.Variance(par[0], par[1]));
-    TF1 *PDF_narrow = new TF1("PDF_narrow", dEdx_PDF_fuction, mu - sigma, mu + sigma, 5);
-    PDF_narrow -> SetParameters(par[0], par[1], par[2], par[3], par[4]);
-    PDF_maxy[0] = PDF_narrow -> GetMaximum();
+    TF1* PDF_narrow = new TF1("PDF_narrow", dEdx_PDF_fuction, mu - sigma, mu + sigma, 5);
+    PDF_narrow->SetParameters(par[0], par[1], par[2], par[3], par[4]);
+    PDF_maxy[0] = PDF_narrow->GetMaximum();
     delete PDF_narrow;
   }
-  else{
-    PDF_maxy[0] = PDF -> GetMaximum();
+  else {
+    PDF_maxy[0] = PDF->GetMaximum();
   }
 
   delete PDF;
-  if(this_PDF_y > 0.) return true;
-  else return false;
+  if (this_PDF_y > 0.)
+    return true;
+  else
+    return false;
 }
 
-double pid::PhysdEdx::dEdx_Gaus_Sigma(double KE, double pitch){
+double pid::PhysdEdx::dEdx_Gaus_Sigma(double KE, double pitch)
+{
 
-  double gamma = (KE/mass)+1.0;
-  double beta = TMath::Sqrt(1-(1.0/(gamma*gamma)));
+  double gamma = (KE / mass) + 1.0;
+  double beta = TMath::Sqrt(1 - (1.0 / (gamma * gamma)));
   double this_xi = Landau_xi(KE, pitch);
   double this_Wmax = Get_Wmax(KE);
   double this_kappa = this_xi / this_Wmax;
@@ -199,6 +211,4 @@ double pid::PhysdEdx::dEdx_Gaus_Sigma(double KE, double pitch){
   return sigma;
 }
 
-pid::PhysdEdx::~PhysdEdx(){
-
-}
+pid::PhysdEdx::~PhysdEdx() {}

--- a/larana/ParticleIdentification/PhysdEdx.cxx
+++ b/larana/ParticleIdentification/PhysdEdx.cxx
@@ -40,19 +40,19 @@ void pid::PhysdEdx::SetPdgCode(int pdg)
   pdgcode = pdg;
 
   if (abs(pdgcode) == 13) { //muon
-    mass = 105.6583755; // MeV
+    mass = 105.6583755;     // MeV
     charge = 1;
   }
   else if (abs(pdgcode) == 211) { //pion
-    mass = 139.57039; // MeV
+    mass = 139.57039;             // MeV
     charge = 1;
   }
   else if (abs(pdgcode) == 321) { //kaon
-    mass = 493.677; // MeV
+    mass = 493.677;               // MeV
     charge = 1;
   }
   else if (pdgcode == 2212) { //proton
-    mass = 938.27208816; // MeV
+    mass = 938.27208816;      // MeV
     charge = 1;
   }
   else {

--- a/larana/ParticleIdentification/PhysdEdx.h
+++ b/larana/ParticleIdentification/PhysdEdx.h
@@ -8,21 +8,20 @@
 #ifndef PHYSDEDX_H
 #define PHYSDEDX_H
 
-#include <map>
 #include "Math/VavilovAccurate.h"
 #include "TF1.h"
+#include <map>
 
 namespace pid {
   class PhysdEdx {
 
   public:
-
     PhysdEdx();
     PhysdEdx(int pdg);
     ~PhysdEdx();
 
     void SetPdgCode(int pdg);
-    int GetPdgCode(){ return pdgcode;};
+    int GetPdgCode() { return pdgcode; };
 
     double Landau_xi(double KE, double pitch);
     double Get_Wmax(double KE);
@@ -31,11 +30,10 @@ namespace pid {
     double KEtoMomentum(double KE);
     double MomentumtoKE(double momentum);
 
-    bool dEdx_PDF(double KE, double pitch, double dEdx, double *PDF_y, double *PDF_maxy);
+    bool dEdx_PDF(double KE, double pitch, double dEdx, double* PDF_y, double* PDF_maxy);
     double dEdx_Gaus_Sigma(double KE, double pitch);
-  
-  private:
 
+  private:
     int pdgcode;
     double mass;
     int charge;
@@ -45,12 +43,12 @@ namespace pid {
     double betaGamma(double KE);
 
     // == Bethe-Bloch parameters, https://indico.fnal.gov/event/14933/contributions/28526/attachments/17961/22583/Final_SIST_Paper.pdf
-    const double rho = 1.39; // [g/cm3], density of LAr
+    const double rho = 1.39;   // [g/cm3], density of LAr
     const double K = 0.307075; // [MeV cm2 / mol]
-    const double Z = 18.; // atomic number of Ar
-    const double A = 39.948; // [g / mol], atomic mass of Ar
+    const double Z = 18.;      // atomic number of Ar
+    const double A = 39.948;   // [g / mol], atomic mass of Ar
     const double I = 197.0e-6; // [MeV], mean excitation energy, JINST 19 (2024) 01, P01009
-    const double me = 0.511; // [Mev], mass of electron
+    const double me = 0.511;   // [Mev], mass of electron
     // == Parameters for the density correction
     const double density_C = 5.2146;
     const double density_y0 = 0.2;
@@ -58,5 +56,5 @@ namespace pid {
     const double density_a = 0.19559;
     const double density_k = 3.0;
   }; //
-} // namespace 
+} // namespace
 #endif // PHYSDEDX_H

--- a/larana/ParticleIdentification/PhysdEdx.h
+++ b/larana/ParticleIdentification/PhysdEdx.h
@@ -1,0 +1,62 @@
+////////////////////////////////////////////////////////////////////////
+//
+// A class for dE/dx functions for likelihood based particleID
+//
+// sungbino@fnal.gov
+//
+////////////////////////////////////////////////////////////////////////
+#ifndef PHYSDEDX_H
+#define PHYSDEDX_H
+
+#include <map>
+#include "Math/VavilovAccurate.h"
+#include "TF1.h"
+
+namespace pid {
+  class PhysdEdx {
+
+  public:
+
+    PhysdEdx();
+    PhysdEdx(int pdg);
+    ~PhysdEdx();
+
+    void SetPdgCode(int pdg);
+    int GetPdgCode(){ return pdgcode;};
+
+    double Landau_xi(double KE, double pitch);
+    double Get_Wmax(double KE);
+    double meandEdx(double KE);
+    double MPVdEdx(double KE, double pitch);
+    double KEtoMomentum(double KE);
+    double MomentumtoKE(double momentum);
+
+    bool dEdx_PDF(double KE, double pitch, double dEdx, double *PDF_y, double *PDF_maxy);
+    double dEdx_Gaus_Sigma(double KE, double pitch);
+  
+  private:
+
+    int pdgcode;
+    double mass;
+    int charge;
+
+    double densityEffect(double beta, double gamma);
+
+    double betaGamma(double KE);
+
+    // == Bethe-Bloch parameters, https://indico.fnal.gov/event/14933/contributions/28526/attachments/17961/22583/Final_SIST_Paper.pdf
+    const double rho = 1.39; // [g/cm3], density of LAr
+    const double K = 0.307075; // [MeV cm2 / mol]
+    const double Z = 18.; // atomic number of Ar
+    const double A = 39.948; // [g / mol], atomic mass of Ar
+    const double I = 197.0e-6; // [MeV], mean excitation energy, JINST 19 (2024) 01, P01009
+    const double me = 0.511; // [Mev], mass of electron
+    // == Parameters for the density correction
+    const double density_C = 5.2146;
+    const double density_y0 = 0.2;
+    const double density_y1 = 3.0;
+    const double density_a = 0.19559;
+    const double density_k = 3.0;
+  }; //
+} // namespace 
+#endif // PHYSDEDX_H

--- a/larana/ParticleIdentification/PhysdEdx.h
+++ b/larana/ParticleIdentification/PhysdEdx.h
@@ -16,11 +16,7 @@ namespace pid {
   class PhysdEdx {
 
   public:
-    PhysdEdx();
     PhysdEdx(int pdg);
-    ~PhysdEdx();
-
-    void SetPdgCode(int pdg);
     int GetPdgCode() { return pdgcode; };
 
     double Landau_xi(double KE, double pitch);
@@ -34,27 +30,14 @@ namespace pid {
     double dEdx_Gaus_Sigma(double KE, double pitch);
 
   private:
+    ROOT::Math::VavilovAccurate vav;
+    void SetPdgCode(int pdg);
     int pdgcode;
     double mass;
     int charge;
 
     double densityEffect(double beta, double gamma);
-
     double betaGamma(double KE);
-
-    // == Bethe-Bloch parameters, https://indico.fnal.gov/event/14933/contributions/28526/attachments/17961/22583/Final_SIST_Paper.pdf
-    const double rho = 1.39;   // [g/cm3], density of LAr
-    const double K = 0.307075; // [MeV cm2 / mol]
-    const double Z = 18.;      // atomic number of Ar
-    const double A = 39.948;   // [g / mol], atomic mass of Ar
-    const double I = 197.0e-6; // [MeV], mean excitation energy, JINST 19 (2024) 01, P01009
-    const double me = 0.511;   // [Mev], mass of electron
-    // == Parameters for the density correction
-    const double density_C = 5.2146;
-    const double density_y0 = 0.2;
-    const double density_y1 = 3.0;
-    const double density_a = 0.19559;
-    const double density_k = 3.0;
   }; //
 } // namespace
 #endif // PHYSDEDX_H

--- a/larana/ParticleIdentification/particleid.fcl
+++ b/larana/ParticleIdentification/particleid.fcl
@@ -9,6 +9,14 @@ standard_chi2pid:
  Chi2PIDAlg:             @local::standard_chi2pidalg
 }
 
+standard_likelihoodpid:
+{
+ module_type:            "LikelihoodParticleID"
+ TrackModuleLabel:       "spacepts"
+ CalorimetryModuleLabel: "calo"
+ Chi2PIDAlg:             @local::standard_likelihoodpidalg
+}
+
 standard_pidaanalyzer:
 {
   module_type:      "PIDAAnalyzer"

--- a/larana/ParticleIdentification/particleid.fcl
+++ b/larana/ParticleIdentification/particleid.fcl
@@ -14,7 +14,7 @@ standard_likelihoodpid:
  module_type:            "LikelihoodParticleID"
  TrackModuleLabel:       "spacepts"
  CalorimetryModuleLabel: "calo"
- Chi2PIDAlg:             @local::standard_likelihoodpidalg
+ LikelihoodPIDAlg:       @local::standard_likelihoodpidalg
 }
 
 standard_pidaanalyzer:

--- a/larana/ParticleIdentification/pidalgorithms.fcl
+++ b/larana/ParticleIdentification/pidalgorithms.fcl
@@ -7,6 +7,11 @@ standard_chi2pidalg:
     # MaximumPIDA:            30 # Optional argument: limits PIDA values that are considered for median or mean
 }
 
+standard_likelihoodpidalg:
+{
+    maxrr: 26.0
+}
+
 standard_pidaalg:
 {
   ExponentConstant: 0.42


### PR DESCRIPTION
Adding `LikelihoodPIDAlg` for a PID based on likelihood of dE/dx.
This is to consider non-Gaussian-like dE/dx distribution (Landau or Vavilov distribution) into PID using r.r and dE/dx.

To save computing resources, dE/dx PDF is approximated to Landau and Gaussian functions depending on the kappa parameter. A information could be found in [here](https://iopscience.iop.org/article/10.1088/1748-0221/20/02/P02021) chapter 2.

For this, adding `PhysdEdx ` too. This is for calling dE/dx PDFs.
Please let me know if there is more appropriate repository to add PhysdEdx class.

Thank you.