### PR TITLE
Add sub-sample linear interpolation to OpHit `RiseTimeThreshold` tool

### DIFF
--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
@@ -62,9 +62,11 @@ namespace pmtana {
       }
     }
 
+    // rise is first sample after threshold is crossed
     auto it_max = max_element(wf_aux.begin(), wf_aux.end());
     double rise = std::lower_bound(wf_aux.begin(), it_max, fPeakRatio * (*it_max)) - wf_aux.begin();
 
+    // linear interpolation
     if(fInterpolateSample && rise > 0){
       rise = InterpolateTicks(rise-1, wf_aux[rise-1], wf_aux[rise], fPeakRatio * (*it_max) );
     }
@@ -72,13 +74,13 @@ namespace pmtana {
     return rise;
   }
 
-double RiseTimeThreshold::InterpolateTicks(size_t i, double yi, double yii, double thr) const 
-{
-  // Linear interpolation to find x at y=thr
-  // between (i,y[i]) and (i+1,y[i+1])
-  double frac = (thr-yi)/(yii-yi);
-  return i + frac;
-}
+  double RiseTimeThreshold::InterpolateTicks(size_t i, double y1, double y2, double thr) const 
+  {
+    // Linear interpolation to find x at y=thr
+    // between (i,y1) and (i+1,y2)
+    double frac = (thr-y1)/(y2-y1);
+    return i + frac;
+  }
 
 }
 

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
@@ -40,8 +40,7 @@ namespace pmtana {
   };
 
   RiseTimeThreshold::RiseTimeThreshold(art::ToolConfigTable<Config> const& config)
-    : fPeakRatio{config().PeakRatio()},
-      fInterpolateSample{config().InterpolateSamples()}
+    : fPeakRatio{config().PeakRatio()}, fInterpolateSample{config().InterpolateSamples()}
   {}
 
   double RiseTimeThreshold::RiseTime(const pmtana::Waveform_t& wf_pulse,
@@ -67,18 +66,18 @@ namespace pmtana {
     double rise = std::lower_bound(wf_aux.begin(), it_max, fPeakRatio * (*it_max)) - wf_aux.begin();
 
     // linear interpolation
-    if(fInterpolateSample && rise > 0){
-      rise = InterpolateTicks(rise-1, wf_aux[rise-1], wf_aux[rise], fPeakRatio * (*it_max) );
+    if (fInterpolateSample && rise > 0) {
+      rise = InterpolateTicks(rise - 1, wf_aux[rise - 1], wf_aux[rise], fPeakRatio * (*it_max));
     }
 
     return rise;
   }
 
-  double RiseTimeThreshold::InterpolateTicks(size_t i, double y1, double y2, double thr) const 
+  double RiseTimeThreshold::InterpolateTicks(size_t i, double y1, double y2, double thr) const
   {
     // Linear interpolation to find x at y=thr
     // between (i,y1) and (i+1,y2)
-    double frac = (thr-y1)/(y2-y1);
+    double frac = (thr - y1) / (y2 - y1);
     return i + frac;
   }
 

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
@@ -34,7 +34,7 @@ namespace pmtana {
                     bool _positive) const override;
 
   private:
-    double InterpolateTicks(size_t i, double yi, double yii, double thr) const;
+    double InterpolateTicks(size_t i, double y1, double y2, double thr) const;
     double fPeakRatio;
     bool fInterpolateSample;
   };
@@ -63,14 +63,14 @@ namespace pmtana {
 
     // rise is first sample after threshold is crossed
     auto it_max = max_element(wf_aux.begin(), wf_aux.end());
-    double rise = std::lower_bound(wf_aux.begin(), it_max, fPeakRatio * (*it_max)) - wf_aux.begin();
+    size_t rise = std::lower_bound(wf_aux.begin(), it_max, fPeakRatio * (*it_max)) - wf_aux.begin();
 
     // linear interpolation
     if (fInterpolateSample && rise > 0) {
-      rise = InterpolateTicks(rise - 1, wf_aux[rise - 1], wf_aux[rise], fPeakRatio * (*it_max));
+      return InterpolateTicks(rise - 1, wf_aux[rise - 1], wf_aux[rise], fPeakRatio * (*it_max));
     }
 
-    return rise;
+    return static_cast<double>rise;
   }
 
   double RiseTimeThreshold::InterpolateTicks(size_t i, double y1, double y2, double thr) const

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
@@ -70,7 +70,7 @@ namespace pmtana {
       return InterpolateTicks(rise - 1, wf_aux[rise - 1], wf_aux[rise], fPeakRatio * (*it_max));
     }
 
-    return static_cast<double> rise;
+    return static_cast<double>(rise);
   }
 
   double RiseTimeThreshold::InterpolateTicks(size_t i, double y1, double y2, double thr) const

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
@@ -21,8 +21,8 @@ namespace pmtana {
   public:
     //Configuration parameters
     struct Config {
-
       fhicl::Atom<double> PeakRatio{fhicl::Name("PeakRatio")};
+      fhicl::Atom<bool> InterpolateSamples{fhicl::Name("InterpolateSamples"), false};
     };
 
     // Default constructor
@@ -34,11 +34,14 @@ namespace pmtana {
                     bool _positive) const override;
 
   private:
+    double InterpolateTicks(size_t i, double yi, double yii, double thr) const;
     double fPeakRatio;
+    bool fInterpolateSample;
   };
 
   RiseTimeThreshold::RiseTimeThreshold(art::ToolConfigTable<Config> const& config)
-    : fPeakRatio{config().PeakRatio()}
+    : fPeakRatio{config().PeakRatio()},
+      fInterpolateSample{config().InterpolateSamples()}
   {}
 
   double RiseTimeThreshold::RiseTime(const pmtana::Waveform_t& wf_pulse,
@@ -60,10 +63,22 @@ namespace pmtana {
     }
 
     auto it_max = max_element(wf_aux.begin(), wf_aux.end());
-    size_t rise = std::lower_bound(wf_aux.begin(), it_max, fPeakRatio * (*it_max)) - wf_aux.begin();
+    double rise = std::lower_bound(wf_aux.begin(), it_max, fPeakRatio * (*it_max)) - wf_aux.begin();
+
+    if(fInterpolateSample && rise > 0){
+      rise = InterpolateTicks(rise-1, wf_aux[rise-1], wf_aux[rise], fPeakRatio * (*it_max) );
+    }
 
     return rise;
   }
+
+double RiseTimeThreshold::InterpolateTicks(size_t i, double yi, double yii, double thr) const 
+{
+  // Linear interpolation to find x at y=thr
+  // between (i,y[i]) and (i+1,y[i+1])
+  double frac = (thr-yi)/(yii-yi);
+  return i + frac;
+}
 
 }
 

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/RiseTimeThreshold_tool.cc
@@ -70,7 +70,7 @@ namespace pmtana {
       return InterpolateTicks(rise - 1, wf_aux[rise - 1], wf_aux[rise], fPeakRatio * (*it_max));
     }
 
-    return static_cast<double>rise;
+    return static_cast<double> rise;
   }
 
   double RiseTimeThreshold::InterpolateTicks(size_t i, double y1, double y2, double thr) const

--- a/larana/OpticalDetector/OpHitFinder/RiseTimeTools/risetimecalculator_tool.fcl
+++ b/larana/OpticalDetector/OpHitFinder/RiseTimeTools/risetimecalculator_tool.fcl
@@ -3,7 +3,8 @@ BEGIN_PROLOG
 RiseTimeThreshold:
 {
     tool_type: RiseTimeThreshold
-    PeakRatio:         0.2
+    PeakRatio:          0.2
+    InterpolateSamples: false
 }
 
 RiseTimeGaussFit:


### PR DESCRIPTION
This PR adds an optional linear interpolation step to the OpHit `RiseTimeThreshold` calculation, allowing sub-sample precision when finding the threshold-crossing time. The tool currently computes the OpHit rise time as the first sample above a threshold relative to the peak of the signal. 

This adds a new FHiCL parameter (`InterpolateSamples`) that enables linear interpolation between the two samples surrounding the threshold crossing. Its default is set to `false` to preserve backward compatibility with the legacy behavior.
In cases where the rise time collapses into the start time (`rise==0`), interpolation is skipped regardless of the setting.
