### PR TITLE
Fixing OpFlashSimpleAna module's retrieval of input module labels

### DIFF
--- a/larana/OpticalDetector/OpFlashSimpleAna_module.cc
+++ b/larana/OpticalDetector/OpFlashSimpleAna_module.cc
@@ -53,7 +53,7 @@ opdet::OpFlashSimpleAna::OpFlashSimpleAna(fhicl::ParameterSet const& p) : EDAnal
 // More initializers here.
 {
   fOpFlashModuleLabel = p.get<std::string>("OpFlashModuleLabel", "");
-  fOpHitModuleLabel = p.get<std::string>("OpFlashModuleLabel", "");
+  fOpHitModuleLabel = p.get<std::string>("OpHitModuleLabel", "");
   fMakeOpDetPEHist = p.get<bool>("MakeOpDetPEHist", true);
 }
 


### PR DESCRIPTION
There was a typo (copy-paste leftover perhaps) which made it impossible to configure the ana module to output ana tree for ophits.