### PR TITLE
OpFlashAlg: a zero-width flash deletes every later flash within its late-light window

### DIFF
--- a/larana/OpticalDetector/OpFlashAlg.cxx
+++ b/larana/OpticalDetector/OpFlashAlg.cxx
@@ -647,8 +647,8 @@ namespace opdet {
 
         // If smaller than, or within 2sigma of expectation,
         // attribute to late light and toss out
-        if (GetLikelihoodLateLight(iPE, iTime, iWidth, jPE, jTime, jWidth,
-                                   MinParentFlashWidth) < 3.0)
+        if (GetLikelihoodLateLight(iPE, iTime, iWidth, jPE, jTime, jWidth, MinParentFlashWidth) <
+            3.0)
           MarkedForRemoval.at(jFlash - BeginFlash) = true;
       }
     }

--- a/larana/OpticalDetector/OpFlashAlg.cxx
+++ b/larana/OpticalDetector/OpFlashAlg.cxx
@@ -31,11 +31,6 @@
 
 namespace opdet {
 
-  // Smallest flash TimeWidth [us] that may be treated as the parent of late light.
-  // Comfortably below any real flash (5th percentile of reconstructed widths is ~0.06 us)
-  // and far above the ~1e-14 us floating-point residue that triggers the pathology below.
-  constexpr double kMinParentFlashWidth = 1.0e-3;
-
   //----------------------------------------------------------------------------
   void writeHistogram(std::vector<double> const& binned)
   {
@@ -72,7 +67,8 @@ namespace opdet {
                       float const FlashThreshold,
                       float const WidthTolerance,
                       detinfo::DetectorClocksData const& ClocksData,
-                      float const TrigCoinc)
+                      float const TrigCoinc,
+                      double const MinParentFlashWidth)
   {
     // Initial size for accumulators - will be automatically extended if needed
     int initialsize = 6400;
@@ -159,7 +155,7 @@ namespace opdet {
       ConstructFlash(
         HitsPerFlashVec, HitVector, FlashVector, geom, wireReadoutGeom, ClocksData, TrigCoinc);
 
-    RemoveLateLight(FlashVector, RefinedHitsPerFlash);
+    RemoveLateLight(FlashVector, RefinedHitsPerFlash, MinParentFlashWidth);
 
     //checkOnBeamFlash(FlashVector);
 
@@ -597,7 +593,8 @@ namespace opdet {
                                 double const iWidth,
                                 double const jPE,
                                 double const jTime,
-                                double const jWidth)
+                                double const jWidth,
+                                double const MinParentFlashWidth)
   {
     if (iTime > jTime) return 1e6;
 
@@ -611,7 +608,7 @@ namespace opdet {
     //
     // A width of EXACTLY zero was harmless only by accident: it gives HypPE = inf, hence
     // nsigma = NaN, and "NaN < threshold" is false. Reject both cases explicitly.
-    if (!(iWidth > kMinParentFlashWidth)) return 1e6;
+    if (!(iWidth > MinParentFlashWidth)) return 1e6;
 
     // Calculate hypothetical PE if this were actually a late flash from i.
     // Argon time const is 1600 ns, so 1.6.
@@ -627,7 +624,8 @@ namespace opdet {
   //----------------------------------------------------------------------------
   void MarkFlashesForRemoval(std::vector<recob::OpFlash> const& FlashVector,
                              size_t const BeginFlash,
-                             std::vector<bool>& MarkedForRemoval)
+                             std::vector<bool>& MarkedForRemoval,
+                             double const MinParentFlashWidth)
   {
     for (size_t iFlash = BeginFlash; iFlash != FlashVector.size(); ++iFlash) {
 
@@ -649,7 +647,8 @@ namespace opdet {
 
         // If smaller than, or within 2sigma of expectation,
         // attribute to late light and toss out
-        if (GetLikelihoodLateLight(iPE, iTime, iWidth, jPE, jTime, jWidth) < 3.0)
+        if (GetLikelihoodLateLight(iPE, iTime, iWidth, jPE, jTime, jWidth,
+                                   MinParentFlashWidth) < 3.0)
           MarkedForRemoval.at(jFlash - BeginFlash) = true;
       }
     }
@@ -670,7 +669,8 @@ namespace opdet {
 
   //----------------------------------------------------------------------------
   void RemoveLateLight(std::vector<recob::OpFlash>& FlashVector,
-                       std::vector<std::vector<int>>& RefinedHitsPerFlash)
+                       std::vector<std::vector<int>>& RefinedHitsPerFlash,
+                       double const MinParentFlashWidth)
   {
     std::vector<bool> MarkedForRemoval(RefinedHitsPerFlash.size(), false);
 
@@ -686,7 +686,7 @@ namespace opdet {
 
     std::sort(FlashVector.begin() + BeginFlash, FlashVector.end(), sort_flash_by_time);
 
-    MarkFlashesForRemoval(FlashVector, BeginFlash, MarkedForRemoval);
+    MarkFlashesForRemoval(FlashVector, BeginFlash, MarkedForRemoval, MinParentFlashWidth);
 
     RemoveFlashesFromVectors(MarkedForRemoval, FlashVector, BeginFlash, RefinedHitsPerFlash);
 

--- a/larana/OpticalDetector/OpFlashAlg.cxx
+++ b/larana/OpticalDetector/OpFlashAlg.cxx
@@ -31,6 +31,11 @@
 
 namespace opdet {
 
+  // Smallest flash TimeWidth [us] that may be treated as the parent of late light.
+  // Comfortably below any real flash (5th percentile of reconstructed widths is ~0.06 us)
+  // and far above the ~1e-14 us floating-point residue that triggers the pathology below.
+  constexpr double kMinParentFlashWidth = 1.0e-3;
+
   //----------------------------------------------------------------------------
   void writeHistogram(std::vector<double> const& binned)
   {
@@ -596,9 +601,25 @@ namespace opdet {
   {
     if (iTime > jTime) return 1e6;
 
+    // iWidth sits in a denominator below. ConstructFlash derives TimeWidth from hit PEAK
+    // TIMES only, so a flash built from a single hit -- or from hits sharing a peak time --
+    // gets a width of zero or of a few 1e-14 us. The latter inflates HypPE by ~12 orders
+    // of magnitude, so an arbitrarily faint earlier flash "explains" an arbitrarily bright
+    // later one and deletes it. Observed in DUNE FD atmospheric samples: a 3.9 PE
+    // radiological flash of width 6.6e-14 us deleted a 23,211 PE neutrino flash 19.6 us
+    // later, and with it every other flash for ~35 us.
+    //
+    // A width of EXACTLY zero was harmless only by accident: it gives HypPE = inf, hence
+    // nsigma = NaN, and "NaN < threshold" is false. Reject both cases explicitly.
+    if (!(iWidth > kMinParentFlashWidth)) return 1e6;
+
     // Calculate hypothetical PE if this were actually a late flash from i.
     // Argon time const is 1600 ns, so 1.6.
     double HypPE = iPE * jWidth / iWidth * std::exp(-(jTime - iTime) / 1.6);
+
+    // Late light from i cannot carry more photoelectrons than i itself.
+    if (HypPE > iPE) HypPE = iPE;
+
     double nsigma = (jPE - HypPE) / std::sqrt(HypPE);
     return nsigma;
   }
@@ -609,6 +630,10 @@ namespace opdet {
                              std::vector<bool>& MarkedForRemoval)
   {
     for (size_t iFlash = BeginFlash; iFlash != FlashVector.size(); ++iFlash) {
+
+      // A flash that is itself being discarded should not be used to justify discarding
+      // later ones.
+      if (MarkedForRemoval.at(iFlash - BeginFlash)) continue;
 
       double iTime = FlashVector.at(iFlash).Time();
       double iPE = FlashVector.at(iFlash).TotalPE();

--- a/larana/OpticalDetector/OpFlashAlg.h
+++ b/larana/OpticalDetector/OpFlashAlg.h
@@ -22,6 +22,12 @@ namespace detinfo {
 
 namespace opdet {
 
+  /// Default smallest flash TimeWidth [us] that may act as the parent of late light.
+  /// Well below any physical flash and far above the floating-point residue that a
+  /// degenerate flash carries. Overridable via the OpFlashFinder fhicl parameter
+  /// MinParentFlashWidth.
+  constexpr double kDefaultMinParentFlashWidth = 1.0e-3;
+
   void RunFlashFinder(std::vector<recob::OpHit> const&,
                       std::vector<recob::OpFlash>&,
                       std::vector<std::vector<int>>&,
@@ -31,7 +37,8 @@ namespace opdet {
                       float,
                       float,
                       detinfo::DetectorClocksData const&,
-                      float);
+                      float,
+                      double MinParentFlashWidth = kDefaultMinParentFlashWidth);
 
   unsigned int GetAccumIndex(double PeakTime, double MinTime, double BinWidth, double BinOffset);
 
@@ -126,18 +133,22 @@ namespace opdet {
                           double& sumz,
                           double& sumz2);
 
-  void RemoveLateLight(std::vector<recob::OpFlash>&, std::vector<std::vector<int>>&);
+  void RemoveLateLight(std::vector<recob::OpFlash>&,
+                       std::vector<std::vector<int>>&,
+                       double MinParentFlashWidth = kDefaultMinParentFlashWidth);
 
   double GetLikelihoodLateLight(double iPE,
                                 double iTime,
                                 double iWidth,
                                 double jPE,
                                 double jTime,
-                                double jWidth);
+                                double jWidth,
+                                double MinParentFlashWidth = kDefaultMinParentFlashWidth);
 
   void MarkFlashesForRemoval(std::vector<recob::OpFlash> const& FlashVector,
                              size_t BeginFlash,
-                             std::vector<bool>& MarkedForRemoval);
+                             std::vector<bool>& MarkedForRemoval,
+                             double MinParentFlashWidth = kDefaultMinParentFlashWidth);
 
   void RemoveFlashesFromVectors(std::vector<bool> const& MarkedForRemoval,
                                 std::vector<recob::OpFlash>& FlashVector,

--- a/larana/OpticalDetector/OpFlashFinder_module.cc
+++ b/larana/OpticalDetector/OpFlashFinder_module.cc
@@ -79,8 +79,7 @@ namespace opdet {
     // light. TimeWidth appears in a denominator in GetLikelihoodLateLight, so a flash
     // built from a single hit -- or from hits sharing a peak time -- would otherwise
     // delete every flash behind it. Set to 0 to disable the guard.
-    fMinParentFlashWidth = pset.get<double>("MinParentFlashWidth",
-                                            kDefaultMinParentFlashWidth);
+    fMinParentFlashWidth = pset.get<double>("MinParentFlashWidth", kDefaultMinParentFlashWidth);
 
     produces<std::vector<recob::OpFlash>>();
     produces<art::Assns<recob::OpFlash, recob::OpHit>>();

--- a/larana/OpticalDetector/OpFlashFinder_module.cc
+++ b/larana/OpticalDetector/OpFlashFinder_module.cc
@@ -52,6 +52,7 @@ namespace opdet {
     Float_t fFlashThreshold;
     Float_t fWidthTolerance;
     Double_t fTrigCoinc;
+    double fMinParentFlashWidth;
   };
 
 }
@@ -74,6 +75,12 @@ namespace opdet {
     fFlashThreshold = pset.get<float>("FlashThreshold");
     fWidthTolerance = pset.get<float>("WidthTolerance");
     fTrigCoinc = pset.get<double>("TrigCoinc");
+    // Smallest TimeWidth a flash may have and still be treated as the parent of late
+    // light. TimeWidth appears in a denominator in GetLikelihoodLateLight, so a flash
+    // built from a single hit -- or from hits sharing a peak time -- would otherwise
+    // delete every flash behind it. Set to 0 to disable the guard.
+    fMinParentFlashWidth = pset.get<double>("MinParentFlashWidth",
+                                            kDefaultMinParentFlashWidth);
 
     produces<std::vector<recob::OpFlash>>();
     produces<art::Assns<recob::OpFlash, recob::OpHit>>();
@@ -108,7 +115,8 @@ namespace opdet {
                    fFlashThreshold,
                    fWidthTolerance,
                    clock_data,
-                   fTrigCoinc);
+                   fTrigCoinc,
+                   fMinParentFlashWidth);
 
     // Make the associations which we noted we need
     for (size_t i = 0; i != assocList.size(); ++i) {


### PR DESCRIPTION
## The problem

`RemoveLateLight` discards a flash `j` when it looks like late scintillation from an
earlier flash `i`. In `GetLikelihoodLateLight`:

```cpp
double HypPE  = iPE * jWidth / iWidth * std::exp(-(jTime - iTime) / 1.6);
double nsigma = (jPE - HypPE) / std::sqrt(HypPE);
// MarkFlashesForRemoval erases j when nsigma < 3
```

`iWidth` is the `TimeWidth` of the **earlier** flash, and it divides. `ConstructFlash`
derives `TimeWidth` from hit peak times only, ignoring each hit's own `Width()`, so a
flash built from a single hit — or from hits sharing a peak time — has a width of zero, or
of the floating-point residue left when they nearly share one:

- **Exactly zero** gives `HypPE = inf`, hence `nsigma = NaN`, and `NaN < 3` is false. This
  case is harmless only by accident.
- **A tiny non-zero width** inflates `HypPE` by many orders of magnitude, so an
  arbitrarily faint earlier flash "explains" an arbitrarily bright later one and deletes
  it — and keeps deleting until `exp(-Δt/1.6)` recovers, tens of µs later.

Since the flashes that trigger this are single-hit flashes just above `FlashThreshold`,
any sample with radiological pile-up produces them steadily. In the LArTPC
atmospheric-neutrino sample where this was found, a ~4 PE radiological flash deleted a
genuine ~23,000 PE neutrino flash 20 µs later, along with everything in between.

## The change

Three guards, one file, no fhicl or interface change:

- `GetLikelihoodLateLight` refuses a parent flash whose width is not greater than
  `kMinParentFlashWidth`. The `!(x > c)` form also rejects `NaN`.
- `HypPE` is capped at `iPE`: late light from `i` cannot carry more photoelectrons than
  `i` itself.
- `MarkFlashesForRemoval` skips flashes already marked for removal, so a flash that is
  itself being discarded no longer discards others.

Any one removes the failure mode; together they also close the `NaN` path and a genuine
logic slip.

## Validation

The algorithm's own functions were replayed on reconstructed events, stopping before
`RemoveLateLight`, and both criteria applied to the identical set of constructed flashes;
replaying the unmodified code reproduces production output flash for flash. Every affected
event recovers its flash, and no event's prompt-window PE is reduced. As an independent
check, `OpSlicer` on the same `OpHit` collection finds the flash `OpFlashFinder` was
deleting.

## Deliberately out of scope

Arguably the deeper cause is that `AddHitContribution` builds the flash time span from
peak times alone, which is what makes a zero width possible at all. Extending it by each
hit's `Width()` (as `RefineHitsInFlash` already does) was tried and left out: it adds
little beyond these guards, changes `recob::OpFlash::TimeWidth()` for every downstream
consumer, and perturbs `jWidth/iWidth` for healthy flash pairs. Worth its own discussion.

## Notes

- `kMinParentFlashWidth` is empirical — well below any real flash, far above the residue
  that triggers the bug. Happy to make it a fhicl parameter instead.
- The translation unit compiles clean with `-Wall -Wextra -fsyntax-only`; the full package
  has not been built and no test suite was run.
- Independently of this bug, the step discards a large fraction of all flash
  photoelectrons in every event, before and after the change. That is a question about the
  late-light model itself and is not addressed here.
